### PR TITLE
fix: add jsconfig for @ alias + blog files

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `jsconfig.json` with `@/*` path alias so markdown blog imports resolve

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_689ec9d933988323a503383ccb965a47