### PR TITLE
fix: use relative imports for posts utilities

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { getAllPosts } from "@/lib/posts";
+import { getAllPosts } from "../lib/posts";
 
 export default function BlogTop() {
   const posts = getAllPosts();

--- a/app/posts/[slug]/page.js
+++ b/app/posts/[slug]/page.js
@@ -1,4 +1,4 @@
-import { getAllPosts, getPost } from "@/lib/posts";
+import { getAllPosts, getPost } from "../../../lib/posts";
 import { remark } from "remark";
 import html from "remark-html";
 

--- a/app/sitemap.js
+++ b/app/sitemap.js
@@ -1,4 +1,4 @@
-import { getAllPosts } from "@/lib/posts";
+import { getAllPosts } from "../lib/posts";
 
 export default async function sitemap() {
   const base = "https://playotoron.com/blog";


### PR DESCRIPTION
## Summary
- replace `@/lib/posts` alias with relative paths in page, posts slug page, and sitemap

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689ecc4b962483239c22df81898d221f