### PR TITLE
Add RSS metadata, breadcrumb JSON-LD, OG image route, and front matter checks

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -12,7 +12,18 @@ export const metadata = {
     locale: "ja_JP",
     type: "website"
   },
-  twitter: { card: "summary_large_image" }
+  twitter: { card: "summary_large_image" },
+  alternates: { canonical: "https://playotoron.com/blog" },
+  other: {
+    "link:alternate:rss": [
+      {
+        rel: "alternate",
+        type: "application/rss+xml",
+        title: "オトロン公式ブログ",
+        href: "https://playotoron.com/blog/rss"
+      }
+    ]
+  }
 };
 
 export default function RootLayout({ children }) {

--- a/app/og/[slug]/route.tsx
+++ b/app/og/[slug]/route.tsx
@@ -1,0 +1,16 @@
+/* eslint-disable react/jsx-key */
+import { ImageResponse } from 'next/og';
+import { getPost } from '@/lib/posts';
+
+export const runtime = 'edge';
+export async function GET(_: Request, { params }: { params: { slug: string } }) {
+  const p = getPost(params.slug);
+  return new ImageResponse(
+    (
+      <div style={{ fontSize: 64, width: 1200, height: 630, display: 'flex', padding: 80, background: '#fff' }}>
+        <div style={{ fontSize: 48, fontWeight: 700, lineHeight: 1.2 }}>{p?.title ?? 'OTORON BLOG'}</div>
+      </div>
+    ),
+    { width: 1200, height: 630 }
+  );
+}

--- a/app/posts/[slug]/page.js
+++ b/app/posts/[slug]/page.js
@@ -13,7 +13,7 @@ export async function generateMetadata({ params }) {
   if (!p) return {};
   const title = `${p.title} | オトロン公式ブログ`;
   const url = `${BASE}/blog/posts/${p.slug}`;
-  const og = p.ogImage || "/ogp.png";
+  const og = p.ogImage || `/og/${p.slug}`;
   return {
     title,
     description: p.description,
@@ -43,7 +43,7 @@ export default async function PostPage({ params }) {
   const url = `${BASE}/blog/posts/${p.slug}`;
   const ogAbs = p.ogImage?.startsWith("http")
     ? p.ogImage
-    : `${BASE}${p.ogImage || "/ogp.png"}`;
+    : `${BASE}${p.ogImage || `/og/${p.slug}`}`;
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
@@ -56,6 +56,14 @@ export default async function PostPage({ params }) {
     publisher: { "@type": "Organization", name: "OTORON" },
     mainEntityOfPage: url
   };
+  const breadcrumb = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "ブログ", item: "https://playotoron.com/blog" },
+      { "@type": "ListItem", position: 2, name: p.title, item: url }
+    ]
+  };
 
   return (
     <article className="post">
@@ -63,6 +71,7 @@ export default async function PostPage({ params }) {
       <h1>{p.title}</h1>
       <div className="meta">{new Date(p.date).toLocaleDateString("ja-JP")}</div>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
       <div dangerouslySetInnerHTML={{ __html: contentHtml }} />
     </article>
   );

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -4,6 +4,11 @@ import matter from "gray-matter";
 
 const postsDir = path.join(process.cwd(), "posts");
 
+function assertFrontMatter(p) {
+  const missing = ["title", "description", "date"].filter(k => !p[k]);
+  if (missing.length) throw new Error(`Front-matter missing: ${missing.join(', ')} in ${p.slug}`);
+}
+
 export function getAllPosts() {
   if (!fs.existsSync(postsDir)) return [];
   const files = fs.readdirSync(postsDir).filter(f => f.endsWith(".md"));
@@ -11,7 +16,9 @@ export function getAllPosts() {
     const slug = file.replace(/\.md$/, "");
     const raw = fs.readFileSync(path.join(postsDir, file), "utf8");
     const { data, content } = matter(raw);
-    return { slug, content, ...data };
+    const p = { slug, content, ...data };
+    assertFrontMatter(p);
+    return p;
   });
   return posts.sort((a,b) => (a.date < b.date ? 1 : -1));
 }
@@ -21,5 +28,7 @@ export function getPost(slug) {
   if (!fs.existsSync(full)) return null;
   const raw = fs.readFileSync(full, "utf8");
   const { data, content } = matter(raw);
-  return { slug, content, ...data };
+  const p = { slug, content, ...data };
+  assertFrontMatter(p);
+  return p;
 }


### PR DESCRIPTION
## Summary
- expose blog RSS feed via head metadata
- embed BreadcrumbList JSON-LD and default OG image per post
- generate dynamic OG images with /og/[slug] route
- validate required front-matter fields on post load

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: missing TypeScript deps; install blocked)


------
https://chatgpt.com/codex/tasks/task_b_689f1a5b36488323937fd03404fe9592