### PR TITLE
feat: render markdown with heading anchors

### DIFF
--- a/app/posts/[slug]/page.js
+++ b/app/posts/[slug]/page.js
@@ -1,6 +1,5 @@
 import { getAllPosts, getPost, getPrevNext } from "../../../lib/posts";
-import { remark } from "remark";
-import html from "remark-html";
+import { renderMarkdown } from "../../../lib/markdown";
 
 const BASE = "https://playotoron.com"; // 1か所に集約
 
@@ -46,8 +45,7 @@ export default async function PostPage({ params }) {
 
   const { prev, next } = getPrevNext(p.slug);
 
-  const processed = await remark().use(html).process(p.content);
-  const contentHtml = processed.toString();
+  const { html: contentHtml } = await renderMarkdown(p.content);
 
   const url = `${BASE}/blog/posts/${p.slug}`;
   const ogAbs = p.ogImage?.startsWith("http")

--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -1,0 +1,33 @@
+import { remark } from 'remark';
+import html from 'remark-html';
+import { visit } from 'unist-util-visit';
+import { toString } from 'mdast-util-to-string';
+
+function slugify(str) {
+  return str
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\u3040-\u30ff\u3400-\u9faf\s-]/g, '')
+    .replace(/\s+/g, '-');
+}
+
+export async function renderMarkdown(md) {
+  const toc = [];
+  const processor = remark().use(() => tree => {
+    visit(tree, 'heading', node => {
+      const text = toString(node);
+      const id = slugify(text);
+      node.data = node.data || {};
+      node.data.hProperties = { ...(node.data.hProperties || {}), id };
+      node.children.push({
+        type: 'link',
+        url: `#${id}`,
+        data: { hProperties: { className: 'anchor', 'aria-hidden': 'true' } },
+        children: [{ type: 'text', value: '#' }]
+      });
+      toc.push({ depth: node.depth, id, title: text });
+    });
+  }).use(html, { sanitize: false });
+  const file = await processor.process(md);
+  return { html: String(file), toc };
+}


### PR DESCRIPTION
## Summary
- add markdown renderer generating heading anchors and TOC data
- use new renderer to display post content

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Failed to install required TypeScript dependencies)

------
https://chatgpt.com/codex/tasks/task_b_689f2f2cab0883239c0e3e4946a6f552