### PR TITLE
feat: render markdown with TOC and sanitization

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -21,3 +21,93 @@ kbd{background:#f6f6f6;border:1px solid #e4e4e7;border-bottom-width:2px;border-r
 .toc li.d3{margin-left:16px}
 .post :is(h2,h3) .anchor{margin-left:6px;text-decoration:none;opacity:.4}
 .post :is(h2,h3):hover .anchor{opacity:.9}
+html {
+  scroll-behavior: smooth; /* TOCクリックで滑らかスクロール */
+}
+
+/* 記事本文の余白とコード・表の最低限スタイル */
+.prose pre {
+  overflow: auto;
+  padding: 1rem;
+  border-radius: .5rem;
+  background: #0b0b0c;
+  color: #f5f5f5;
+}
+.prose code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+  font-size: .95em;
+}
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1rem 0;
+}
+.prose th, .prose td {
+  border: 1px solid rgba(0,0,0,.08);
+  padding: .5rem .75rem;
+}
+.prose img {
+  max-width: 100%;
+  height: auto;
+}
+
+/* TOC 共通 */
+.toc,
+.toc-wrap {
+  font-size: .95rem;
+  line-height: 1.6;
+}
+.toc a,
+.toc-link {
+  text-decoration: none;
+}
+.toc a:hover,
+.toc-link:hover {
+  text-decoration: underline;
+}
+
+/* モバイル：記事上部の折りたたみ目次 */
+.toc-mobile {
+  display: block;
+  margin: 0 0 1rem;
+}
+.toc-details {
+  border: 1px solid rgba(0,0,0,.08);
+  border-radius: .5rem;
+  padding: .5rem .75rem;
+  background: #fff;
+}
+.toc-summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+/* PC：サイド固定レイアウト */
+.post-body-with-toc {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 2rem;
+}
+.toc-aside {
+  position: sticky;
+  top: 88px;               /* ヘッダー高に合わせて調整 */
+  height: max-content;
+  align-self: start;
+  border-left: 2px solid rgba(0,0,0,.06);
+  padding-left: 1rem;
+}
+
+/* スマホではサイドTOCを非表示、上部TOCのみ */
+@media (max-width: 1024px) {
+  .post-body-with-toc {
+    display: block;
+  }
+  .toc-aside {
+    display: none;
+  }
+}
+
+/* 見出しにアンカーで飛んだ時に被らないよう余白確保 */
+.prose h1, .prose h2, .prose h3, .prose h4, .prose h5, .prose h6 {
+  scroll-margin-top: 84px; /* ヘッダー固定時の被り防止 */
+}

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -1,56 +1,145 @@
-import { unified } from 'unified';
-import parse from 'remark-parse';
-import gfm from 'remark-gfm';
-import slug from 'remark-slug';
-import autolink from 'remark-autolink-headings';
-import remark2rehype from 'remark-rehype';
-import sanitize from 'rehype-sanitize';
-import stringify from 'rehype-stringify';
-import externalLinks from 'rehype-external-links';
+import { unified } from "unified";
+import parse from "remark-parse";
+import gfm from "remark-gfm";
+import smartypants from "remark-smartypants";
+import remark2rehype from "remark-rehype";
+import rehypeStringify from "rehype-stringify";
+import slug from "rehype-slug";
+import autolink from "rehype-autolink-headings";
+import externalLinks from "rehype-external-links";
+import rehypeToc from "rehype-toc";
+import sanitize from "rehype-sanitize";
+import type { Root } from "hast";
+import { defaultSchema } from "hast-util-sanitize";
 
-export type TocItem = { depth: number; value: string; id: string };
+// ---- 設定：sanitize allowlist（表・コード・画像など許可） ----
+const schema: any = structuredClone(defaultSchema);
 
-function uniqueSlug(base: string, used = new Set<string>()) {
-  let s = base; let i = 2;
-  while (used.has(s)) s = `${base}-${i++}`;
-  used.add(s);
-  return s;
+// 追加タグ
+schema.tagNames = Array.from(
+  new Set([
+    ...(schema.tagNames ?? []),
+    "section",
+    "details",
+    "summary",
+    "table",
+    "thead",
+    "tbody",
+    "tr",
+    "th",
+    "td",
+    "pre",
+    "code",
+    "img",
+  ])
+);
+
+// a要素の追加属性
+schema.attributes = {
+  ...(schema.attributes ?? {}),
+  a: [
+    ...(schema.attributes?.a ?? []),
+    "href",
+    "name",
+    "target",
+    "rel",
+    "aria-label",
+  ],
+  img: [
+    ...(schema.attributes?.img ?? []),
+    "src",
+    "alt",
+    "title",
+    "width",
+    "height",
+    "decoding",
+    "loading",
+  ],
+  code: [
+    ...(schema.attributes?.code ?? []),
+    // rehype-prism など導入時に className を許可
+    ["className", /^language-[\w-]+$/],
+  ],
+  th: [...(schema.attributes?.th ?? []), "align"],
+  td: [...(schema.attributes?.td ?? []), "align"],
+};
+
+// headingアンカーリンクの見た目（自動で小さなリンクアイコンを追加しない）
+const autolinkOptions = {
+  behavior: "append" as const,
+  content: () => ({
+    type: "text",
+    value: "",
+  }),
+};
+
+// TOC出力を受け取るための一時変数
+function captureToc() {
+  let tocHtml = "";
+  return {
+    plugin: () =>
+      function rehypeTocCapture(tree: Root) {
+        // rehype-toc 実行後、tree 内に .toc を含むノードが乗るので、
+        // 文字列化の前に抽出するのではなく、2パスに分ける。
+        // → 今回は rehype-toc を1回目のパイプラインで走らせ、文字列化結果から抽出する方式にする。
+      },
+    get html() {
+      return tocHtml;
+    },
+    set(html: string) {
+      tocHtml = html;
+    },
+  };
 }
 
-export async function renderMarkdown(md: string): Promise<{ html: string; toc: TocItem[] }> {
-  const file = await unified()
+/**
+ * Markdown文字列を安全にHTMLへ変換し、
+ * 本文HTMLとTOC(目次)HTMLを返す
+ */
+export async function renderMarkdown(md: string): Promise<{ html: string; toc: string }> {
+  // 1パス目：TOC付きでHTML化
+  const withToc = await unified()
     .use(parse)
     .use(gfm)
-    .use(slug)                               // 見出しにid付与
-    .use(autolink, { behavior: 'append' })   // 見出し末尾にアンカー
+    .use(smartypants)
     .use(remark2rehype, { allowDangerousHtml: false })
-    .use(sanitize, {
-      attributes: {
-        '*': ['className', 'id'],
-        a: ['href', 'name', 'target', 'rel', 'aria-hidden', 'title'],
-        img: ['src', 'alt', 'title', 'width', 'height', 'loading', 'decoding'],
+    .use(slug) // 見出しにid付与
+    .use(autolink, autolinkOptions)
+    .use(externalLinks, { target: "_blank", rel: ["noopener", "noreferrer"] })
+    .use(rehypeToc, {
+      headings: ["h1", "h2", "h3"],
+      cssClasses: {
+        toc: "toc",
+        list: "toc-list",
+        listItem: "toc-item",
+        link: "toc-link",
       },
     })
-    .use(externalLinks, { target: '_blank', rel: ['noopener', 'noreferrer'] })
-    .use(stringify)
+    .use(sanitize, schema)
+    .use(rehypeStringify)
     .process(md);
 
-  // 簡易TOC生成（h2/h3）
-  const toc: TocItem[] = [];
-  const used = new Set<string>();
-  for (const line of md.split('\n')) {
-    const m = line.match(/^(#{2,3})\s+(.*)$/);
-    if (!m) continue;
-    const depth = m[1].length;
-    const raw = m[2].trim();
-    const base = raw
-      .toLowerCase()
-      .replace(/[^\p{L}\p{N}\s-]/gu, '')
-      .replace(/\s+/g, '-')
-      .replace(/-+/g, '-');
-    const id = uniqueSlug(base || 'section', used);
-    toc.push({ depth, value: raw, id });
-  }
+  const withTocHtml = String(withToc);
 
-  return { html: String(file), toc };
+  // 2パス目：同じ内容をTOCなしで本文のみHTML化（TOCは別枠で出すため）
+  const withoutToc = await unified()
+    .use(parse)
+    .use(gfm)
+    .use(smartypants)
+    .use(remark2rehype, { allowDangerousHtml: false })
+    .use(slug)
+    .use(autolink, autolinkOptions)
+    .use(externalLinks, { target: "_blank", rel: ["noopener", "noreferrer"] })
+    .use(sanitize, schema)
+    .use(rehypeStringify)
+    .process(md);
+
+  const bodyHtml = String(withoutToc);
+
+  // withTocHtml から .toc セクションだけを切り出す（簡易抽出）
+  // rehypeをもう一度使うのもアリだが、軽量に正規化された構造前提で抽出
+  const tocMatch = withTocHtml.match(/<nav class="toc"[\s\S]*?<\/nav>/);
+  const tocHtml = tocMatch ? tocMatch[0] : "";
+
+  return { html: bodyHtml, toc: tocHtml };
 }

--- a/package.json
+++ b/package.json
@@ -12,17 +12,19 @@
     "next": "14.2.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "gray-matter": "4.0.3",
-    "remark": "15.0.1",
-    "remark-html": "16.0.1",
+    "gray-matter": "4.0.3"
+  },
+  "devDependencies": {
     "unified": "^11.0.0",
     "remark-parse": "^10.0.0",
     "remark-gfm": "^4.0.0",
-    "remark-slug": "^7.0.0",
-    "remark-autolink-headings": "^7.0.0",
+    "remark-smartypants": "^2.0.0",
     "remark-rehype": "^11.0.0",
     "rehype-stringify": "^10.0.0",
-    "rehype-sanitize": "^6.0.0",
-    "rehype-external-links": "^3.0.0"
+    "rehype-slug": "^6.0.0",
+    "rehype-autolink-headings": "^6.1.1",
+    "rehype-external-links": "^3.0.0",
+    "rehype-toc": "^3.0.0",
+    "rehype-sanitize": "^6.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- sanitize markdown and extract table of contents
- show responsive TOC on posts
- style prose, code blocks, tables, and TOC layout

## Testing
- `npm run build` *(fails: Module not found: Can't resolve 'remark-smartypants')*
- `npm run start` *(fails: Could not find a production build)*

------
https://chatgpt.com/codex/tasks/task_b_689f3d7197788323a3909fcc5f66b0a3