### PR TITLE
feat(blog/ui): refresh blog list UI and TOC styles

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -118,3 +118,64 @@ html {
 .toc li { margin: 4px 0; }
 .toc a { text-decoration: none; }
 .toc a:hover { text-decoration: underline; }
+
+/* === Blog UI refresh === */
+:root {
+  --brand: #7c3aed;             /* violet 600 */
+  --brand-ink: #5b21b6;         /* violet 700 */
+  --ink: #0f172a;               /* slate 900 */
+  --muted: #64748b;             /* slate 500 */
+  --bg: #ffffff;
+  --surface: #ffffff;
+  --border: #e5e7eb;            /* gray 200 */
+  --ring: #c4b5fd;              /* violet 300 */
+  --shadow: 0 8px 24px rgba(15, 23, 42, .08);
+}
+
+.wrap { max-width: 960px; margin: 0 auto; padding: 56px 20px 80px; color: var(--ink); }
+
+.breadcrumb { font-size: 14px; margin-bottom: 14px; }
+.breadcrumb .brand { color: var(--brand); font-weight: 700; text-decoration: none; }
+.breadcrumb a:hover { text-decoration: underline; }
+
+.page-title { font-size: clamp(32px, 4.2vw, 48px); line-height: 1.1; font-weight: 800; letter-spacing: -.02em; margin: 8px 0 8px; }
+.lede { color: var(--muted); margin-bottom: 18px; }
+
+/* Search */
+.search { display: flex; gap: 8px; align-items: center; margin: 18px 0 28px; }
+.search input {
+  flex: 1 1 auto; min-width: 0; font-size: 16px;
+  padding: 10px 12px; border: 1px solid var(--border); border-radius: 10px; background: #fff;
+}
+.search .btn {
+  padding: 10px 14px; border-radius: 10px; border: 1px solid var(--brand);
+  background: var(--brand); color: #fff; font-weight: 700; cursor: pointer;
+}
+.search .btn:hover { background: var(--brand-ink); border-color: var(--brand-ink); }
+.search input:focus-visible, .search .btn:focus-visible {
+  outline: none; box-shadow: 0 0 0 3px var(--ring);
+}
+
+/* Cards */
+.cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 20px; margin-top: 8px; }
+.cards__item { list-style: none; }
+.card {
+  display: block; padding: 18px 18px 20px; background: var(--surface);
+  border: 1px solid var(--border); border-radius: 16px; box-shadow: var(--shadow);
+  text-decoration: none; color: inherit; transition: transform .15s ease, box-shadow .15s ease, border-color .15s ease;
+}
+.card:hover { transform: translateY(-2px); box-shadow: 0 12px 28px rgba(15, 23, 42, .10); border-color: #d4d4d8; }
+.card__title { color: var(--brand); font-weight: 800; font-size: 20px; line-height: 1.35; margin: 0 0 6px; }
+.card__date { display: block; font-size: 12px; color: var(--muted); margin-bottom: 10px; }
+.card__desc { color: #334155; margin: 0; }
+
+/* Helpers */
+.muted { color: var(--muted); margin-top: 12px; }
+.foot { margin-top: 40px; font-size: 12px; color: var(--muted); }
+.visually-hidden { position: absolute !important; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); border: 0; }
+
+/* TOC（記事ページ） */
+.toc-aside { position: sticky; top: 96px; max-height: calc(100vh - 120px); overflow: auto; }
+.toc-aside nav.toc { font-size: 14px; }
+.toc-aside a { color: var(--brand); text-decoration: none; }
+.toc-aside a:hover { text-decoration: underline; }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,11 @@
 // app/page.tsx
 import { getAllPosts } from "@/lib/posts";
 
-/** メタデータ（canonical は /blog 固定） */
 export async function generateMetadata() {
   const BASE = "https://playotoron.com";
   const title = "オトロン公式ブログ";
   const description =
     "絶対音感トレーニングのノウハウ、幼児の耳育て、アプリ活用ガイドなどをお届けします。";
-
   return {
     title,
     description,
@@ -28,17 +26,13 @@ export async function generateMetadata() {
 
 type SearchParams = { q?: string };
 
-/** 一覧ページ（/）。検索はクエリパラメータ ?q= でサーバー側フィルタ */
 export default async function Home({
   searchParams,
 }: {
   searchParams: SearchParams;
 }) {
   const q = (searchParams?.q ?? "").trim().toLowerCase();
-
-  // 投稿一覧（draftは lib/posts 側で除外済み）
-  const all: any[] = getAllPosts();
-
+  const all = getAllPosts();
   const posts = q
     ? all.filter((p) => {
         const hay = `${p.title ?? ""} ${p.description ?? ""} ${p.slug}`.toLowerCase();
@@ -47,58 +41,50 @@ export default async function Home({
     : all;
 
   return (
-    <main className="container mx-auto px-4 py-10">
-      {/* パンくず（簡易） */}
-      <nav className="text-sm mb-6 text-violet-700">
-        <a href="/" className="font-semibold">
-          オトロン
-        </a>{" "}
-        / ブログ
+    <main className="wrap">
+      <nav className="breadcrumb">
+        <a href="/" className="brand">オトロン</a> <span>/ ブログ</span>
       </nav>
 
-      <h1 className="text-5xl font-extrabold tracking-tight mb-3">
-        オトロン公式ブログ
-      </h1>
-      <p className="text-gray-600 mb-6">
+      <h1 className="page-title">オトロン公式ブログ</h1>
+      <p className="lede">
         絶対音感トレーニングのノウハウ、幼児の耳育て、アプリ活用ガイドなどをお届けします。
       </p>
 
-      {/* 検索フォーム（GETで/?q=） */}
-      <form action="/" method="get" className="mb-6">
+      {/* 検索（GET /?q=） */}
+      <form action="/" method="get" className="search">
+        <label htmlFor="q" className="visually-hidden">検索</label>
         <input
+          id="q"
           name="q"
           defaultValue={q}
-          placeholder="検索"
-          className="border rounded px-3 py-2 w-full max-w-md"
-          aria-label="記事検索"
+          placeholder="キーワードで検索"
+          inputMode="search"
         />
+        <button type="submit" className="btn">検索</button>
       </form>
 
       {/* 一覧 */}
-      <section className="grid grid-cols-1 md:grid-cols-2 gap-5">
+      <ul className="cards" role="list">
         {posts.map((p) => (
-          <a
-            key={p.slug}
-            href={`/blog/posts/${p.slug}`} // /blog → rewrites で /posts へ
-            className="block rounded-2xl border border-gray-200 p-5 shadow-sm hover:shadow transition"
-          >
-            <h2 className="text-violet-700 text-xl font-semibold leading-snug">
-              {p.title}
-            </h2>
-            <div className="text-sm text-gray-500 mt-1">
-              {new Date(p.date).toLocaleDateString("ja-JP")}
-            </div>
-            <p className="text-gray-700 mt-2">{p.description}</p>
-          </a>
+          <li key={p.slug} className="cards__item">
+            <a href={`/blog/posts/${p.slug}`} className="card">
+              <h2 className="card__title">{p.title}</h2>
+              <time className="card__date" dateTime={p.date}>
+                {new Date(p.date).toLocaleDateString("ja-JP")}
+              </time>
+              <p className="card__desc">{p.description}</p>
+            </a>
+          </li>
         ))}
-      </section>
+      </ul>
 
-      {/* ヒットなし */}
       {posts.length === 0 && (
-        <p className="text-gray-600 mt-8">該当する記事が見つかりませんでした。</p>
+        <p className="muted">該当する記事が見つかりませんでした。</p>
       )}
 
-      <footer className="text-xs text-gray-500 mt-12">© 2025 OTORON</footer>
+      <footer className="foot">© 2025 OTORON</footer>
     </main>
   );
 }
+


### PR DESCRIPTION
## Summary
- add search form button and card-based blog list layout
- add custom CSS variables and helpers
- style sidebar TOC to be sticky and lightweight

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_689fed9dee588323afff2af76309182f