### PR TITLE
refactor blog index layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -141,8 +141,9 @@ html {
 .breadcrumb .brand:hover { text-decoration: underline; }
 .breadcrumb .current { color: #6b7280; }
 
-.page-title { font-size: clamp(32px, 4.2vw, 48px); line-height: 1.1; font-weight: 800; letter-spacing: -.02em; margin: 8px 0 8px; }
-.lede { color: var(--muted); margin-bottom: 18px; }
+.page-title { font-size: clamp(28px, 2.8vw + 10px, 44px); line-height: 1.2; letter-spacing: .01em; margin: 8px 0 10px; }
+.lede { color:#61656d; margin-bottom: 22px; }
+main { padding-top: 24px; }
 
 /* Search */
 .search { display: flex; gap: 8px; align-items: center; margin: 18px 0 28px; }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,6 @@
 // app/page.tsx
 import { getAllPosts } from "@/lib/posts";
 import type { BlogPost } from "@/types/posts";
-import Breadcrumb from "@/components/Breadcrumb";
 
 export async function generateMetadata() {
   const BASE = "https://playotoron.com";
@@ -60,9 +59,25 @@ export default async function Home({
     ? all.filter((p) => allText(p).includes(q))
     : all;
 
+  const listLd = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "オトロン公式ブログ",
+    description:
+      "絶対音感トレーニングのノウハウ、幼児の耳育て、アプリ活用ガイドなどをお届けします。",
+    mainEntity: {
+      "@type": "ItemList",
+      itemListElement: posts.map((p, i) => ({
+        "@type": "ListItem",
+        position: i + 1,
+        url: `${process.env.NEXT_PUBLIC_BASE_URL || "https://playotoron.com"}/blog/posts/${p.slug}`,
+      })),
+    },
+  };
+
   return (
     <main className="wrap">
-      <Breadcrumb items={[{ label: "オトロン", href: "/" }, { label: "ブログ" }]} />
+      {/* 一覧のパンくずは表示しない（記事ページのみ） */}
 
       <h1 className="page-title">オトロン公式ブログ</h1>
       <p className="lede">
@@ -80,7 +95,7 @@ export default async function Home({
           placeholder="キーワードで検索"
           inputMode="search"
         />
-        <button type="submit" className="btn-search">検索</button>
+        {/* Enterで送信できるのでボタンは省略可 */}
       </form>
 
       {/* 一覧 */}
@@ -101,6 +116,11 @@ export default async function Home({
       {posts.length === 0 && (
         <p className="muted">該当する記事が見つかりませんでした。</p>
       )}
+
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(listLd) }}
+      />
 
       <footer className="foot">© 2025 OTORON</footer>
     </main>


### PR DESCRIPTION
## Summary
- drop breadcrumb from blog index and rely on article pages only
- remove search submit button and include JSON-LD ItemList
- adjust typography and spacing for title and lede

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_b_689ffe7a1e708323b27bdd049d8cb149