### PR TITLE
feat(ui): SEO-first minimal blog UI

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -136,10 +136,6 @@ html {
 
 .wrap { max-width: 960px; margin: 0 auto; padding: 56px 20px 80px; color: var(--ink); }
 
-.breadcrumb { color: #6b7280; margin-bottom: 18px; font-size: 14px; }
-.breadcrumb .brand { color: var(--brand); text-decoration: none; }
-.breadcrumb .brand:hover { text-decoration: underline; }
-.breadcrumb .current { color: #6b7280; }
 
 .page-title { font-size: clamp(28px, 2.8vw + 10px, 44px); line-height: 1.2; letter-spacing: .01em; margin: 8px 0 10px; }
 .lede { color:#61656d; margin-bottom: 22px; }
@@ -178,3 +174,81 @@ main { padding-top: 24px; }
 .toc-aside nav.toc { font-size: 14px; }
 .toc-aside a { color: var(--brand); text-decoration: none; }
 .toc-aside a:hover { text-decoration: underline; }
+
+/* ==== Blog minimal refresh (SEO-first) ==== */
+:root{
+  --brand: #6f46ff;
+  --brand-ink: #fff;
+  --ink: #0f1222;
+  --ink-weak: #4a4d6a;
+  --border: rgba(15,18,34,.08);
+  --surface: #fff;
+  --ring: 0 0 0 4px rgba(111,70,255,.20);
+}
+
+.wrap{max-width: 1000px; margin: 56px auto; padding: 0 20px;}
+.page-title{font-size: clamp(28px,3.6vw,44px); line-height: 1.15; letter-spacing:.02em; font-weight: 800; margin: 8px 0 10px;}
+.lede{color: var(--ink-weak); margin: 0 0 28px;}
+
+.visually-hidden{position:absolute!important; clip:rect(1px,1px,1px,1px); padding:0; border:0; height:1px; width:1px; overflow:hidden;}
+
+.search{display:flex; gap:12px; align-items:center; margin: 18px 0 28px;}
+.search__input{
+  flex: 1 1 auto; height: 48px; font-size: 16px;
+  padding: 0 14px; border-radius: 12px; border: 1px solid var(--border);
+  background: var(--surface); outline: none;
+}
+.search__input:focus{box-shadow: var(--ring); border-color: var(--brand);}
+
+.btn{display:inline-flex; align-items:center; justify-content:center; height:48px; padding:0 18px; border-radius:12px; font-weight:700; border:0; cursor:pointer;}
+.btn--brand{background: var(--brand); color: var(--brand-ink);}
+.btn--brand:hover{filter: brightness(1.02);}
+.btn--brand:focus-visible{box-shadow: var(--ring);}
+
+.cards{
+  display:grid; grid-template-columns: repeat(auto-fit, minmax(280px,1fr));
+  gap: 18px; margin: 18px 0 52px;
+}
+.card{list-style: none;}
+.card__link{
+  display:block; background: var(--surface);
+  padding: 18px 18px 16px; border: 1px solid var(--border);
+  border-radius: 16px; text-decoration: none; color: inherit;
+  box-shadow: 0 4px 16px rgba(15,18,34,.05);
+  transition: transform .15s ease, box-shadow .15s ease;
+}
+.card__link:hover{ transform: translateY(-2px); box-shadow: 0 6px 24px rgba(15,18,34,.08); }
+.card__title{color: var(--brand); font-weight: 800; line-height: 1.35; margin: 2px 0 8px;}
+.card__date{color: var(--ink-weak); font-size: 12px; margin-bottom: 6px;}
+.card__desc{color: var(--ink-weak); margin: 0;}
+
+.backline{margin: 6px 0 6px;}
+.backlink{color: var(--ink-weak); text-decoration: none;}
+.backlink:hover{ text-decoration: underline;}
+
+.post__title{font-size: clamp(22px,3vw,36px); font-weight: 800; margin: 6px 0 8px;}
+.post__meta{color: var(--ink-weak); margin-bottom: 18px;}
+
+.post-body-with-toc{display: grid; grid-template-columns: minmax(0,1fr); gap: 24px;}
+@media (min-width: 1000px){
+  .post-body-with-toc{ grid-template-columns: 1fr 280px; }
+  .toc-aside{ order: 2; position: sticky; top: 20px; align-self: start; }
+}
+.toc-aside nav, .toc-aside ul{margin:0; padding:0; list-style:none;}
+.toc-aside a{ color: var(--ink-weak); text-decoration: none; }
+.toc-aside a:hover{text-decoration: underline;}
+
+.prose{max-width: 70ch;}
+.prose h2{margin: 28px 0 12px; font-size: 22px;}
+.prose h3{margin: 22px 0 8px; font-size: 18px;}
+.prose p{line-height: 1.9; margin: 12px 0;}
+.prose ul, .prose ol{margin: 12px 0 12px 1.25em;}
+.prose a{color: var(--brand); text-decoration: underline;}
+.prose img{max-width: 100%; height: auto; border-radius: 8px;}
+
+.pn{display:flex; justify-content:space-between; gap: 12px; margin: 24px 0;}
+.pn a{text-decoration:none; color: var(--brand);}
+.pn a:hover{text-decoration: underline;}
+
+.copyright{color: var(--ink-weak); font-size: 12px; margin: 48px 0 12px;}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,12 @@
 // app/page.tsx
 import { getAllPosts } from "@/lib/posts";
-import type { BlogPost } from "@/types/posts";
 
 export async function generateMetadata() {
   const BASE = "https://playotoron.com";
   const title = "オトロン公式ブログ";
   const description =
     "絶対音感トレーニングのノウハウ、幼児の耳育て、アプリ活用ガイドなどをお届けします。";
+
   return {
     title,
     description,
@@ -17,7 +17,7 @@ export async function generateMetadata() {
       url: `${BASE}/blog`,
       title,
       description,
-      images: [{ url: "/og-plain.png", width: 1200, height: 630 }],
+      images: [{ url: "/og/blog", width: 1200, height: 630 }],
       locale: "ja_JP",
     },
     twitter: { card: "summary_large_image" },
@@ -27,102 +27,58 @@ export async function generateMetadata() {
 
 type SearchParams = { q?: string };
 
-export default async function Home({
-  searchParams,
-}: {
-  searchParams: SearchParams;
-}) {
-  const all: BlogPost[] = getAllPosts();
-
-  // Markdownをざっくり素のテキストに
-  const mdToText = (md: string) =>
-    md
-      // コードブロック・インラインコードを間引く
-      .replace(/```[\s\S]*?```/g, " ")
-      .replace(/`[^`]+`/g, " ")
-      // 画像/リンク表記
-      .replace(/!\[[^\]]*\]\([^)]*\)/g, " ")
-      .replace(/\[[^\]]*\]\([^)]*\)/g, " ")
-      // 見出し・強調などの記号
-      .replace(/[#>*_~\-+]+/g, " ")
-      // 余分な空白
-      .replace(/\s{2,}/g, " ")
-      // 重くならないように上限をかける
-      .slice(0, 3000);
-
+export default async function Home({ searchParams }: { searchParams: SearchParams }) {
   const q = (searchParams?.q ?? "").trim().toLowerCase();
-  const allText = (p: BlogPost) =>
-    `${p.title ?? ""} ${p.description ?? ""} ${p.slug} ${mdToText(p.content)}`
-      .toLowerCase();
+  const all = getAllPosts();
 
+  // ※検索は「タイトル＋説明＋スラッグ」のみ（軽量・高速）
   const posts = q
-    ? all.filter((p) => allText(p).includes(q))
+    ? all.filter((p) => {
+        const hay = `${p.title ?? ""} ${p.description ?? ""} ${p.slug}`.toLowerCase();
+        return hay.includes(q);
+      })
     : all;
-
-  const listLd = {
-    "@context": "https://schema.org",
-    "@type": "CollectionPage",
-    name: "オトロン公式ブログ",
-    description:
-      "絶対音感トレーニングのノウハウ、幼児の耳育て、アプリ活用ガイドなどをお届けします。",
-    mainEntity: {
-      "@type": "ItemList",
-      itemListElement: posts.map((p, i) => ({
-        "@type": "ListItem",
-        position: i + 1,
-        url: `${process.env.NEXT_PUBLIC_BASE_URL || "https://playotoron.com"}/blog/posts/${p.slug}`,
-      })),
-    },
-  };
 
   return (
     <main className="wrap">
-      {/* 一覧のパンくずは表示しない（記事ページのみ） */}
-
+      {/* ← パンくずは削除。ヘッダは大きく1つだけ */}
       <h1 className="page-title">オトロン公式ブログ</h1>
       <p className="lede">
         絶対音感トレーニングのノウハウ、幼児の耳育て、アプリ活用ガイドなどをお届けします。
       </p>
 
-      {/* 検索（GET /?q=） */}
-      <form action="/" method="get" className="search">
-        <label htmlFor="q" className="visually-hidden">検索</label>
+      {/* 検索（GETクエリ） */}
+      <form action="/blog" method="get" className="search" role="search">
+        <label htmlFor="q" className="visually-hidden">ブログ内検索</label>
         <input
           id="q"
           name="q"
           type="search"
-          defaultValue={q}
-          placeholder="キーワードで検索"
           inputMode="search"
+          placeholder="キーワードで検索（タイトル・説明）"
+          defaultValue={q}
+          className="search__input"
+          aria-label="ブログ内検索"
         />
-        {/* Enterで送信できるのでボタンは省略可 */}
+        <button type="submit" className="btn btn--brand">検索</button>
       </form>
 
-      {/* 一覧 */}
-      <ul className="cards" role="list">
+      {/* カード一覧 */}
+      <ul className="cards" aria-live="polite">
         {posts.map((p) => (
-          <li key={p.slug} className="cards__item">
-            <a href={`/blog/posts/${p.slug}`} className="card">
-              <h2 className="card_title">{p.title}</h2>
-              <time className="card__date" dateTime={p.date}>
+          <li key={p.slug} className="card">
+            <a href={`/blog/posts/${p.slug}`} className="card__link">
+              <div className="card__title">{p.title}</div>
+              <div className="card__date">
                 {new Date(p.date).toLocaleDateString("ja-JP")}
-              </time>
-              <p className="card_desc">{p.description}</p>
+              </div>
+              <p className="card__desc">{p.description}</p>
             </a>
           </li>
         ))}
       </ul>
 
-      {posts.length === 0 && (
-        <p className="muted">該当する記事が見つかりませんでした。</p>
-      )}
-
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(listLd) }}
-      />
-
-      <footer className="foot">© 2025 OTORON</footer>
+      <footer className="copyright">© 2025 OTORON</footer>
     </main>
   );
 }

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -1,6 +1,5 @@
 import { getAllPosts, getPost, getPrevNext } from "@/lib/posts";
 import { renderMarkdown } from "@/lib/markdown";
-import Breadcrumb from "@/components/Breadcrumb";
 
 const BASE = "https://playotoron.com"; // 1か所に集約
 
@@ -32,12 +31,6 @@ export async function generateMetadata({ params }: { params: { slug: string } })
     twitter: { card: "summary_large_image" },
     robots: p.draft ? { index: false, follow: false } : undefined
   };
-}
-
-function readingTime(text: string) {
-  const wpm = 400;
-  const words = text.replace(/\s+/g, "").length;
-  return Math.max(1, Math.round(words / wpm)) + "分";
 }
 
 export default async function PostPage({ params }: { params: { slug: string } }) {
@@ -74,50 +67,31 @@ export default async function PostPage({ params }: { params: { slug: string } })
   };
 
   return (
-    <>
-      <Breadcrumb
-        items={[
-          { label: "オトロン", href: "/" },
-          { label: "ブログ", href: "/blog" },
-          { label: p.title }
-        ]}
-      />
-      <article className="post">
-        <a href="/blog" className="meta">← 記事一覧へ</a>
-      <h1>{p.title}</h1>
-      <div className="meta">
-        {new Date(p.date).toLocaleDateString("ja-JP")}
-        {" ・ 読了目安: "}{readingTime(p.content)}
+    <article className="post">
+      <p className="backline">
+        <a href="/blog" className="backlink">← 記事一覧へ</a>
+      </p>
+
+      <h1 className="post__title">{p.title}</h1>
+      <div className="post__meta">
+        {new Date(p.date).toLocaleDateString("ja-JP")}・読了目安:{" "}
+        {Math.max(1, Math.round(p.content.replace(/\s+/g, "").length / 400))}分
       </div>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
 
-      {/* スマホ：上部に目次（必要なら details で折りたたみ） */}
-      <div className="toc-mobile">
-        {toc ? (
-          <details open className="toc-details">
-            <summary className="toc-summary">目次</summary>
-            <div className="toc-wrap" dangerouslySetInnerHTML={{ __html: toc }} />
-          </details>
-        ) : null}
-      </div>
-
+      {/* 目次（PCは右、SPは上） */}
       <div className="post-body-with-toc">
-        {/* PC：サイド固定の目次 */}
         {toc ? (
-          <aside className="toc-aside" aria-label="目次">
-            <div dangerouslySetInnerHTML={{ __html: toc }} />
-          </aside>
+          <aside className="toc-aside" aria-label="目次" dangerouslySetInnerHTML={{ __html: toc }} />
         ) : null}
-
-        <div className="prose max-w-none" dangerouslySetInnerHTML={{ __html: html }} />
+        <div className="prose" dangerouslySetInnerHTML={{ __html: html }} />
       </div>
 
-        <nav className="pn">
-          {prev && <a href={`/blog/posts/${prev.slug}`}>← {prev.title}</a>}
-          {next && <a href={`/blog/posts/${next.slug}`}>{next.title} →</a>}
-        </nav>
-      </article>
-    </>
+      <nav className="pn">
+        {prev && <a href={`/blog/posts/${prev.slug}`}>← {prev.title}</a>}
+        {next && <a href={`/blog/posts/${next.slug}`}>{next.title} →</a>}
+      </nav>
+    </article>
   );
 }


### PR DESCRIPTION
## Summary
- streamline blog index with lightweight search and card layout
- simplify post page with top backlink and streamlined table of contents
- refresh global styles for SEO-focused minimal UI and remove breadcrumb remnants

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(configuration prompt for ESLint)*


------
https://chatgpt.com/codex/tasks/task_b_68a0021c2a3c83238b3d0e8c4e213b54