### PR TITLE
fix(og): use nodejs runtime for OG route; revert node:fs/path to fs/path

### DIFF
--- a/app/og/[slug]/route.tsx
+++ b/app/og/[slug]/route.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from "next/og";
 import { getPost } from "@/lib/posts";
 
-export const runtime = "edge";
+export const runtime = "nodejs";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -1,6 +1,6 @@
 // lib/posts.js
-import fs from "node:fs";
-import path from "node:path";
+import fs from "fs";
+import path from "path";
 import matter from "gray-matter";
 
 const POSTS_DIR = path.join(process.cwd(), "posts");


### PR DESCRIPTION
## Summary
- run OG image generation route on Node.js runtime instead of Edge
- switch `lib/posts` back to `fs` and `path` imports

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run build` *(fails: `size` is not a valid Route export field)*

------
https://chatgpt.com/codex/tasks/task_b_68a02d24fe7c832384ec7bf042c5136d