### PR TITLE
feat: centralize brand color

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,8 +1,8 @@
-:root{--brand:#7c4dff;--ink:#111;--muted:#666;--bg:#fff;}
 *{box-sizing:border-box}
 html,body{margin:0;padding:0;background:var(--bg);color:var(--ink);font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,"Apple Color Emoji","Segoe UI Emoji";}
-a{color:var(--brand);text-decoration:none}
-a:hover{text-decoration:underline}
+a,.brand{color:var(--brand);text-decoration:none}
+a:hover{text-decoration:underline;text-decoration-color:var(--brand-600)}
+a:focus-visible{outline:2px solid var(--brand-600);outline-offset:2px}
 .container{max-width:920px;margin-inline:auto;padding:24px}
 .hero{font-size:40px;font-weight:900;letter-spacing:.01em;margin:8px 0 4px}
 .sub{color:var(--muted);margin:0 0 24px}
@@ -120,20 +120,6 @@ html {
 .toc a:hover { text-decoration: underline; }
 
 /* === Blog UI refresh === */
-:root {
-  --brand: #7c3aed;             /* violet 600 */
-  --brand-ink: #5b21b6;         /* violet 700 */
-  --ink: #0f172a;               /* slate 900 */
-  --muted: #64748b;             /* slate 500 */
-  --bg: #ffffff;
-  --surface: #ffffff;
-  --border: #e5e7eb;            /* gray 200 */
-  --ring: #c4b5fd;              /* violet 300 */
-  --shadow: 0 8px 24px rgba(15, 23, 42, .08);
-  --shadow-sm: 0 2px 4px rgba(15, 23, 42, .06);
-  --shadow-lg: 0 12px 28px rgba(15, 23, 42, .10);
-}
-
 .wrap { max-width: 960px; margin: 0 auto; padding: 56px 20px 80px; color: var(--ink); }
 
 
@@ -178,12 +164,19 @@ main { padding-top: 24px; }
 /* ==== Blog minimal refresh (SEO-first) ==== */
 :root{
   --brand: #6c46ff;
+  --brand-600: color-mix(in oklab, var(--brand), black 16%);
+  --brand-100: color-mix(in oklab, var(--brand), white 82%);
   --brand-ink: #fff;
   --ink: #0f1222;
   --ink-weak: #4a4d6a;
+  --muted: #666;
+  --bg: #fff;
   --border: rgba(0,0,0,.08);
   --surface: #fff;
-  --ring: 0 0 0 4px rgba(111,70,255,.20);
+  --ring: 0 0 0 4px var(--brand-600);
+  --shadow: 0 8px 24px rgba(15, 23, 42, .08);
+  --shadow-sm: 0 2px 4px rgba(15, 23, 42, .06);
+  --shadow-lg: 0 12px 28px rgba(15, 23, 42, .10);
 }
 
 .wrap{max-width: 1000px; margin: 56px auto; padding: 0 20px;}
@@ -200,10 +193,9 @@ main { padding-top: 24px; }
 }
 .search__input:focus{box-shadow: var(--ring); border-color: var(--brand);}
 
-.btn{display:inline-flex; align-items:center; justify-content:center; height:48px; padding:0 18px; border-radius:12px; font-weight:700; border:0; cursor:pointer;}
-.btn--brand{background: var(--brand); color: var(--brand-ink);}
-.btn--brand:hover{filter: brightness(1.02);}
-.btn--brand:focus-visible{box-shadow: var(--ring);}
+.btn{display:inline-flex; align-items:center; justify-content:center; height:48px; padding:0 18px; border-radius:12px; font-weight:700; border:0; cursor:pointer; background: var(--brand); color: var(--brand-ink);}
+.btn:hover{filter: brightness(1.02); box-shadow: 0 8px 20px color-mix(in oklab, var(--brand), black 82% / 18%);}
+.btn:focus-visible{outline:2px solid var(--brand-600); outline-offset:2px;}
 
 .cards{
   display:grid; grid-template-columns: repeat(auto-fit, minmax(280px,1fr));
@@ -243,7 +235,7 @@ main { padding-top: 24px; }
 .prose h3{margin: 22px 0 8px; font-size: 18px;}
 .prose p{line-height: 1.9; margin: 12px 0;}
 .prose ul, .prose ol{margin: 12px 0 12px 1.25em;}
-.prose a{color: var(--brand); text-decoration: underline;}
+.prose a{color: var(--brand); text-decoration: underline; text-decoration-color: var(--brand-600);}
 .prose img{max-width: 100%; height: auto; border-radius: 8px;}
 
 .pn{

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 
 export const metadata = {
   metadataBase: new URL("https://playotoron.com"),
+  themeColor: "#6c46ff",
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/app/og/[slug]/route.tsx
+++ b/app/og/[slug]/route.tsx
@@ -9,6 +9,8 @@ export async function GET(_: Request, { params }: { params: { slug: string } }) 
   const p = getPost(params.slug);
   const title = p?.title ?? "OTORON BLOG";
 
+  const brand = "#6c46ff";
+
   return new ImageResponse(
     (
       <div
@@ -19,15 +21,17 @@ export async function GET(_: Request, { params }: { params: { slug: string } }) 
           flexDirection: "column",
           justifyContent: "center",
           padding: "64px 72px",
-          background: "linear-gradient(135deg,#ffffff,#f7f5ff)",
+          "--brand": brand,
+          "--brand-100": "color-mix(in oklab, var(--brand), white 82%)",
+          background: "linear-gradient(135deg,#ffffff,var(--brand-100))",
           fontFamily: "system-ui, -apple-system, Segoe UI, Noto Sans JP, sans-serif",
         }}
       >
-        <div style={{ fontSize: 30, color: "#6c46ff", marginBottom: 16 }}>OTORON BLOG</div>
+        <div style={{ fontSize: 30, color: "var(--brand)", marginBottom: 16 }}>OTORON BLOG</div>
         <div style={{ fontSize: 64, fontWeight: 800, lineHeight: 1.15, whiteSpace: "pre-wrap" }}>
           {title}
         </div>
-        <div style={{ position: "absolute", bottom: 40, right: 72, fontSize: 28, opacity: .7 }}>
+        <div style={{ position: "absolute", bottom: 40, right: 72, fontSize: 28, opacity: .7, color: "var(--brand)" }}>
           playotoron.com
         </div>
       </div>


### PR DESCRIPTION
## Summary
- define brand color and derived variants in CSS
- apply brand color to links, buttons, focus states, and generated OGP images
- set theme color metadata to match brand

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(interactive setup prompt)*

------
https://chatgpt.com/codex/tasks/task_b_68a02f4bbb2c8323bbe0e6c0052e3aa1