### PR TITLE
feat: add toc component

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -454,3 +454,19 @@ h1.page-title{ font-size:clamp(28px,5vw,40px); line-height:1.2; margin:24px 0 8p
   opacity: 1;
   transform: translateY(0);
 }
+/* --- TOC layout & style --- */
+.toc { width: 240px; font-size: 0.95rem; line-height: 1.75; color: #334155; }
+.toc ol { list-style: none; padding-left: 0; margin: 0; }
+.toc-li { margin: .2rem 0; }
+.toc-li--lvl3 { padding-left: 1rem; }
+.toc-link { display: inline-block; text-decoration: none; color: inherit; border-left: 3px solid transparent; padding-left: .5rem; }
+.toc-link:hover { text-decoration: underline; }
+.toc-link.is-active { border-left-color: #60a5fa; color: #1f2937; font-weight: 600; }
+
+/* モバイル折りたたみ */
+.toc-mobile { margin-top: 1rem; }
+.toc-mobile-summary { cursor: pointer; padding: .5rem .75rem; border: 1px solid #e5e7eb; border-radius: .5rem; background: #fff; }
+
+/* --- Heading jump offset (fixed header対策) --- */
+article h2, article h3 { scroll-margin-top: 96px; }
+

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -7,6 +7,7 @@ import {
   getRelatedPosts,
 } from "@/lib/posts";
 import PostCard from "@/components/PostCard";
+import TableOfContents from "@/components/TableOfContents";
 
 const BASE = "https://playotoron.com";
 const FALLBACK_THUMB = "/otolon_face.webp";
@@ -42,77 +43,87 @@ export async function generateMetadata({ params }: { params: { slug: string } })
   };
 }
 
-function readingTime(content: string) {
-  return Math.max(1, Math.round(content.replace(/\s+/g, "").length / 400));
-}
-
 export default async function PostPage({ params }: { params: { slug: string } }) {
-  const p: any = await getPostBySlug(params.slug);
-  if (!p || p.draft) return notFound();
+  const post: any = await getPostBySlug(params.slug);
+  if (!post || post.draft) return notFound();
 
-  const { prev, next }: any = await getAdjacentPosts(p.slug);
-  const related = await getRelatedPosts(p.slug, 2);
-  const hero = p.thumb || p.ogImage || FALLBACK_THUMB;
-  const canonical = `/blog/posts/${p.slug}`;
+  const { prev, next }: any = await getAdjacentPosts(post.slug);
+  const related = await getRelatedPosts(post.slug, 2);
+  const hero = post.thumb || post.ogImage || FALLBACK_THUMB;
+  const canonical = `/blog/posts/${post.slug}`;
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
-    headline: p.title,
-    datePublished: p.date,
-    dateModified: p.updated ?? p.date,
+    headline: post.title,
+    datePublished: post.date,
+    dateModified: post.updated ?? post.date,
     image: hero,
     url: `${BASE}${canonical}`,
-    description: p.description,
+    description: post.description,
   };
 
   return (
-    <article className="post">
-      <header className="postHeader">
-        <div className="heroMedia">
-          <Image
-            src={hero}
-            alt={p.title}
-            fill
-            priority
-            sizes="100vw"
-            className="heroMediaImg"
-          />
-        </div>
-        <h1 className="postTitle">{p.title}</h1>
-        <div className="meta">
-          {new Date(p.date).toLocaleDateString("ja-JP")} ・ 読了目安: {readingTime(p.content)}分
-        </div>
-      </header>
+    <main className="mx-auto max-w-5xl px-4 py-8">
+      <div className="grid grid-cols-1 gap-8 md:grid-cols-[minmax(0,1fr)_240px]">
+        {/* 本文 */}
+        <article className="max-w-3xl">
+          <header className="mb-6">
+            <h1 className="text-2xl font-bold">{post.title}</h1>
+            <time className="mt-2 block text-sm text-gray-500">
+              {new Date(post.date).toLocaleDateString('ja-JP')}
+            </time>
+            <div className="relative mt-4 aspect-[16/9] w-full overflow-hidden rounded-xl border border-gray-100">
+              <Image src={hero} alt={post.title} fill priority sizes="(max-width:768px) 100vw, 720px" className="object-cover" />
+            </div>
+          </header>
 
-      <div className="post-body" dangerouslySetInnerHTML={{ __html: p.html }} />
-
-      <nav className="pn">
-        {prev && <a href={`/blog/posts/${prev.slug}`}>← {prev.title}</a>}
-        {next && <a href={`/blog/posts/${next.slug}`}>{next.title} →</a>}
-      </nav>
-
-      {related.length > 0 && (
-        <section style={{ marginTop: "48px" }}>
-          <h2 style={{ fontSize: "18px", margin: "0 0 16px" }}>関連記事</h2>
-          <div className="cards">
-            {related.map((r: any) => (
-              <PostCard
-                key={r.slug}
-                slug={r.slug}
-                title={r.title}
-                description={r.description}
-                date={r.date}
-                thumb={r.thumb || r.ogImage}
-              />
-            ))}
+          <div className="prose prose-blue max-w-none">
+            <div dangerouslySetInnerHTML={{ __html: post.html }} />
           </div>
-        </section>
-      )}
 
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-      />
-    </article>
+          {/* 前後記事 …（既存のまま） */}
+          <nav className="mt-10 flex justify-between text-sm">
+            <div>{prev && <a href={`/blog/posts/${prev.slug}`} className="underline">← {prev.title}</a>}</div>
+            <div>{next && <a href={`/blog/posts/${next.slug}`} className="underline">{next.title} →</a>}</div>
+          </nav>
+
+          {/* 既に実装済みの関連記事セクション（このまま） */}
+          {related.length > 0 && (
+            <section style={{ marginTop: "48px" }}>
+              <h2 style={{ fontSize: "18px", margin: "0 0 16px" }}>関連記事</h2>
+              <div className="cards">
+                {related.map((r: any) => (
+                  <PostCard
+                    key={r.slug}
+                    slug={r.slug}
+                    title={r.title}
+                    description={r.description}
+                    date={r.date}
+                    thumb={r.thumb || r.ogImage}
+                  />
+                ))}
+              </div>
+            </section>
+          )}
+
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+          />
+        </article>
+
+        {/* 目次（右サイド固定） */}
+        <aside className="hidden md:block">
+          {/* post.headings があれば渡す。無ければ未指定でOK（DOMから抽出） */}
+          <TableOfContents headings={post.headings} />
+        </aside>
+
+        {/* モバイルの折りたたみ版（本文末尾に表示したい場合はここに） */}
+        <div className="md:hidden">
+          <TableOfContents headings={post.headings} />
+        </div>
+      </div>
+    </main>
   );
 }
+

--- a/components/TableOfContents.tsx
+++ b/components/TableOfContents.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+type Heading = { id: string; text: string; depth: number };
+
+function dedupeId(id: string) {
+  return id?.trim().replace(/\s+/g, '-').toLowerCase();
+}
+
+export default function TableOfContents({
+  headings,
+  stickyOffset = 96,
+}: { headings?: Heading[]; stickyOffset?: number }) {
+  const [items, setItems] = useState<Heading[]>(headings ?? []);
+
+  useEffect(() => {
+    if (items.length > 0) return;
+    const nodes = Array.from(document.querySelectorAll('article h2, article h3')) as HTMLElement[];
+    const hs = nodes
+      .filter((el) => el.id || el.textContent)
+      .map((el) => ({
+        id: el.id || dedupeId(el.textContent || ''),
+        text: (el.textContent || '').trim(),
+        depth: el.tagName === 'H3' ? 3 : 2,
+      }));
+    setItems(hs);
+  }, [items.length]);
+
+  const [activeId, setActiveId] = useState<string>('');
+  useEffect(() => {
+    const targets = Array.from(document.querySelectorAll('article h2, article h3'));
+    if (!targets.length) return;
+
+    const obs = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => (a.target as HTMLElement).offsetTop - (b.target as HTMLElement).offsetTop);
+        if (visible[0]) setActiveId((visible[0].target as HTMLElement).id);
+      },
+      { rootMargin: `-${stickyOffset + 8}px 0px -70% 0px`, threshold: [0, 1] }
+    );
+    targets.forEach((t) => obs.observe(t));
+    return () => obs.disconnect();
+  }, [stickyOffset, items.length]);
+
+  const content = useMemo(() => (
+    <nav aria-label="目次" className="toc">
+      <ol>
+        {items.map((h) => (
+          <li key={h.id} className={h.depth === 3 ? 'toc-li toc-li--lvl3' : 'toc-li'}>
+            <a
+              href={`#${h.id}`}
+              className={`toc-link ${activeId === h.id ? 'is-active' : ''}`}
+            >
+              {h.text}
+            </a>
+          </li>
+        ))}
+      </ol>
+    </nav>
+  ), [items, activeId]);
+
+  return (
+    <>
+      <div className="hidden md:block sticky" style={{ top: stickyOffset }}>{content}</div>
+      <details className="md:hidden toc-mobile">
+        <summary className="toc-mobile-summary">目次</summary>
+        {content}
+      </details>
+    </>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add TableOfContents component with active section tracking and mobile details view
- integrate TOC sidebar into post page layout
- style TOC and heading scroll offsets

## Testing
- `npm run lint` *(fails: asks for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68a09e9fd3a8832383811f97e8004fcc