### PR TITLE
Refactor TOC component and post layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -454,19 +454,16 @@ h1.page-title{ font-size:clamp(28px,5vw,40px); line-height:1.2; margin:24px 0 8p
   opacity: 1;
   transform: translateY(0);
 }
-/* --- TOC layout & style --- */
-.toc { width: 240px; font-size: 0.95rem; line-height: 1.75; color: #334155; }
+/* 目次 */
+.toc { width: 100%; font-size: 0.95rem; line-height: 1.75; color: #334155; }
 .toc ol { list-style: none; padding-left: 0; margin: 0; }
 .toc-li { margin: .2rem 0; }
 .toc-li--lvl3 { padding-left: 1rem; }
 .toc-link { display: inline-block; text-decoration: none; color: inherit; border-left: 3px solid transparent; padding-left: .5rem; }
 .toc-link:hover { text-decoration: underline; }
 .toc-link.is-active { border-left-color: #60a5fa; color: #1f2937; font-weight: 600; }
-
-/* モバイル折りたたみ */
-.toc-mobile { margin-top: 1rem; }
 .toc-mobile-summary { cursor: pointer; padding: .5rem .75rem; border: 1px solid #e5e7eb; border-radius: .5rem; background: #fff; }
 
-/* --- Heading jump offset (fixed header対策) --- */
+/* 見出しのアンカーずれ対策（ヘッダー分の余白） */
 article h2, article h3 { scroll-margin-top: 96px; }
 

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -64,16 +64,23 @@ export default async function PostPage({ params }: { params: { slug: string } })
 
   return (
     <main className="mx-auto max-w-5xl px-4 py-8">
-      <div className="grid grid-cols-1 gap-8 md:grid-cols-[minmax(0,1fr)_240px]">
-        {/* 本文 */}
-        <article className="max-w-3xl">
+      <div className="grid grid-cols-1 gap-8 md:grid-cols-12">
+        {/* 本文（8カラム） */}
+        <article className="md:col-span-8">
           <header className="mb-6">
             <h1 className="text-2xl font-bold">{post.title}</h1>
             <time className="mt-2 block text-sm text-gray-500">
               {new Date(post.date).toLocaleDateString('ja-JP')}
             </time>
             <div className="relative mt-4 aspect-[16/9] w-full overflow-hidden rounded-xl border border-gray-100">
-              <Image src={hero} alt={post.title} fill priority sizes="(max-width:768px) 100vw, 720px" className="object-cover" />
+              <Image
+                src={hero}
+                alt={post.title}
+                fill
+                priority
+                sizes="(max-width:768px) 100vw, 720px"
+                className="object-cover"
+              />
             </div>
           </header>
 
@@ -83,28 +90,48 @@ export default async function PostPage({ params }: { params: { slug: string } })
 
           {/* 前後記事 …（既存のまま） */}
           <nav className="mt-10 flex justify-between text-sm">
-            <div>{prev && <a href={`/blog/posts/${prev.slug}`} className="underline">← {prev.title}</a>}</div>
-            <div>{next && <a href={`/blog/posts/${next.slug}`} className="underline">{next.title} →</a>}</div>
+            <div>
+              {prev && (
+                <a href={`/blog/posts/${prev.slug}`} className="underline">
+                  ← {prev.title}
+                </a>
+              )}
+            </div>
+            <div>
+              {next && (
+                <a href={`/blog/posts/${next.slug}`} className="underline">
+                  {next.title} →
+                </a>
+              )}
+            </div>
           </nav>
 
-          {/* 既に実装済みの関連記事セクション（このまま） */}
-          {related.length > 0 && (
-            <section style={{ marginTop: "48px" }}>
-              <h2 style={{ fontSize: "18px", margin: "0 0 16px" }}>関連記事</h2>
-              <div className="cards">
-                {related.map((r: any) => (
+          {/* 関連記事（← 重複があれば他を削除して1回だけに） */}
+          {related?.length > 0 && (
+            <section aria-labelledby="related" className="mt-12">
+              <h2 id="related" className="text-lg font-semibold">
+                関連記事
+              </h2>
+              <div className="mt-4 grid grid-cols-1 gap-6 sm:grid-cols-2">
+                {related.map((p: any) => (
                   <PostCard
-                    key={r.slug}
-                    slug={r.slug}
-                    title={r.title}
-                    description={r.description}
-                    date={r.date}
-                    thumb={r.thumb || r.ogImage}
+                    key={p.slug}
+                    slug={p.slug}
+                    title={p.title}
+                    description={p.description}
+                    date={p.date}
+                    thumb={p.thumb}
                   />
                 ))}
               </div>
             </section>
           )}
+
+          {/* モバイルの目次（折りたたみ） */}
+          <details className="md:hidden toc-mobile mt-10">
+            <summary className="toc-mobile-summary">目次</summary>
+            <TableOfContents headings={post.headings} />
+          </details>
 
           <script
             type="application/ld+json"
@@ -112,16 +139,12 @@ export default async function PostPage({ params }: { params: { slug: string } })
           />
         </article>
 
-        {/* 目次（右サイド固定） */}
-        <aside className="hidden md:block">
-          {/* post.headings があれば渡す。無ければ未指定でOK（DOMから抽出） */}
-          <TableOfContents headings={post.headings} />
+        {/* 右サイド（4カラム） */}
+        <aside className="hidden md:block md:col-span-4">
+          <div className="sticky top-24">
+            <TableOfContents headings={post.headings} />
+          </div>
         </aside>
-
-        {/* モバイルの折りたたみ版（本文末尾に表示したい場合はここに） */}
-        <div className="md:hidden">
-          <TableOfContents headings={post.headings} />
-        </div>
       </div>
     </main>
   );

--- a/components/TableOfContents.tsx
+++ b/components/TableOfContents.tsx
@@ -1,75 +1,55 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 type Heading = { id: string; text: string; depth: number };
 
-function dedupeId(id: string) {
-  return id?.trim().replace(/\s+/g, '-').toLowerCase();
+function slugify(s: string) {
+  return s.trim().toLowerCase().replace(/\s+/g, '-').replace(/[^\w\-]/g, '');
 }
 
-export default function TableOfContents({
-  headings,
-  stickyOffset = 96,
-}: { headings?: Heading[]; stickyOffset?: number }) {
-  const [items, setItems] = useState<Heading[]>(headings ?? []);
+export default function TableOfContents({ headings = [] as Heading[] }) {
+  const [items, setItems] = useState<Heading[]>(headings);
 
   useEffect(() => {
     if (items.length > 0) return;
     const nodes = Array.from(document.querySelectorAll('article h2, article h3')) as HTMLElement[];
-    const hs = nodes
-      .filter((el) => el.id || el.textContent)
-      .map((el) => ({
-        id: el.id || dedupeId(el.textContent || ''),
-        text: (el.textContent || '').trim(),
-        depth: el.tagName === 'H3' ? 3 : 2,
-      }));
+    const hs: Heading[] = nodes.map((el) => {
+      const text = (el.textContent || '').trim();
+      if (!el.id) el.id = slugify(text); // ← 見出しに実IDを付与（重要）
+      return { id: el.id, text, depth: el.tagName === 'H3' ? 3 : 2 };
+    });
     setItems(hs);
   }, [items.length]);
 
-  const [activeId, setActiveId] = useState<string>('');
+  const [active, setActive] = useState('');
   useEffect(() => {
     const targets = Array.from(document.querySelectorAll('article h2, article h3'));
     if (!targets.length) return;
-
-    const obs = new IntersectionObserver(
-      (entries) => {
-        const visible = entries
+    const io = new IntersectionObserver(
+      (ents) => {
+        const top = ents
           .filter((e) => e.isIntersecting)
-          .sort((a, b) => (a.target as HTMLElement).offsetTop - (b.target as HTMLElement).offsetTop);
-        if (visible[0]) setActiveId((visible[0].target as HTMLElement).id);
+          .sort((a, b) => (a.target as HTMLElement).offsetTop - (b.target as HTMLElement).offsetTop)[0];
+        if (top) setActive((top.target as HTMLElement).id);
       },
-      { rootMargin: `-${stickyOffset + 8}px 0px -70% 0px`, threshold: [0, 1] }
+      { rootMargin: '-96px 0px -70% 0px', threshold: [0, 1] }
     );
-    targets.forEach((t) => obs.observe(t));
-    return () => obs.disconnect();
-  }, [stickyOffset, items.length]);
+    targets.forEach((t) => io.observe(t));
+    return () => io.disconnect();
+  }, []);
 
-  const content = useMemo(() => (
+  return (
     <nav aria-label="目次" className="toc">
       <ol>
         {items.map((h) => (
           <li key={h.id} className={h.depth === 3 ? 'toc-li toc-li--lvl3' : 'toc-li'}>
-            <a
-              href={`#${h.id}`}
-              className={`toc-link ${activeId === h.id ? 'is-active' : ''}`}
-            >
+            <a href={`#${h.id}`} className={`toc-link ${active === h.id ? 'is-active' : ''}`}>
               {h.text}
             </a>
           </li>
         ))}
       </ol>
     </nav>
-  ), [items, activeId]);
-
-  return (
-    <>
-      <div className="hidden md:block sticky" style={{ top: stickyOffset }}>{content}</div>
-      <details className="md:hidden toc-mobile">
-        <summary className="toc-mobile-summary">目次</summary>
-        {content}
-      </details>
-    </>
   );
 }
-


### PR DESCRIPTION
## Summary
- simplify TableOfContents to output only nav structure with automatic heading IDs
- restructure post page into responsive 12‑column grid with single related section and TOC placements
- adjust global TOC styles and heading scroll offset

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration and exits)*

------
https://chatgpt.com/codex/tasks/task_b_68a0a22af68083239b0d5e95604782ea