### PR TITLE
feat: refine toc generation

### DIFF
--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -84,7 +84,7 @@ export default async function PostPage({ params }: { params: { slug: string } })
             </div>
           </header>
 
-          <div className="prose prose-blue max-w-none">
+          <div id="post-body" className="prose prose-blue max-w-none">
             <div dangerouslySetInnerHTML={{ __html: post.html }} />
           </div>
 
@@ -127,11 +127,13 @@ export default async function PostPage({ params }: { params: { slug: string } })
             </section>
           )}
 
-          {/* ▼ モバイルは折りたたみ（ここは表示OKだったのでこのまま） */}
-          <details className="md:hidden toc-mobile mt-10">
-            <summary className="toc-mobile-summary">目次</summary>
-            <TableOfContents headings={post.headings} />
-          </details>
+          {/* モバイル TOC（本文に見出しが無い場合は非表示にしたい場合のみ） */}
+          {post.headings?.length ? (
+            <details className="md:hidden toc-mobile mt-10">
+              <summary className="toc-mobile-summary">目次</summary>
+              <TableOfContents headings={post.headings} />
+            </details>
+          ) : null}
 
           <script
             type="application/ld+json"

--- a/components/TableOfContents.tsx
+++ b/components/TableOfContents.tsx
@@ -13,10 +13,12 @@ export default function TableOfContents({ headings = [] as Heading[] }) {
 
   useEffect(() => {
     if (items.length > 0) return;
-    const nodes = Array.from(document.querySelectorAll('article h2, article h3')) as HTMLElement[];
+    const root = document.querySelector('#post-body');
+    if (!root) return;
+    const nodes = Array.from(root.querySelectorAll('h2, h3')) as HTMLElement[];
     const hs: Heading[] = nodes.map((el) => {
       const text = (el.textContent || '').trim();
-      if (!el.id) el.id = slugify(text); // ← 見出しに実IDを付与（重要）
+      if (!el.id) el.id = slugify(text);
       return { id: el.id, text, depth: el.tagName === 'H3' ? 3 : 2 };
     });
     setItems(hs);
@@ -24,7 +26,9 @@ export default function TableOfContents({ headings = [] as Heading[] }) {
 
   const [active, setActive] = useState('');
   useEffect(() => {
-    const targets = Array.from(document.querySelectorAll('article h2, article h3'));
+    const root = document.querySelector('#post-body');
+    if (!root) return;
+    const targets = Array.from(root.querySelectorAll('h2, h3'));
     if (!targets.length) return;
     const io = new IntersectionObserver(
       (ents) => {
@@ -38,6 +42,8 @@ export default function TableOfContents({ headings = [] as Heading[] }) {
     targets.forEach((t) => io.observe(t));
     return () => io.disconnect();
   }, []);
+
+  if (!items.length) return null;
 
   return (
     <nav aria-label="目次" className="toc">

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -29,6 +29,7 @@ function collectToc() {
 
     if (!headings.length) {
       file.data.toc = null;
+      file.data.headings = [];
       return;
     }
 
@@ -45,6 +46,7 @@ function collectToc() {
     }
     html += "</ul></li></ul></nav>";
     file.data.toc = html;
+    file.data.headings = headings;
   };
 }
 
@@ -77,7 +79,9 @@ const schema = {
   ],
 };
 
-export async function renderMarkdown(md: string): Promise<{ html: string; toc: string | null }> {
+export async function renderMarkdown(
+  md: string
+): Promise<{ html: string; toc: string | null; headings: { depth: number; id: string; text: string }[] }> {
   const file = await unified()
     .use(remarkParse)
     .use(remarkGfm)
@@ -103,5 +107,6 @@ export async function renderMarkdown(md: string): Promise<{ html: string; toc: s
   return {
     html: String(file),
     toc: (file.data as any).toc ?? null,
+    headings: (file.data as any).headings ?? [],
   };
 }

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -108,8 +108,8 @@ export function getAllSlugs() {
 export async function getPostBySlug(slug) {
   const p = getPost(slug);
   if (!p) return null;
-  const { html } = await renderMarkdown(p.content);
-  return { ...p, html };
+  const { html, headings } = await renderMarkdown(p.content);
+  return { ...p, html, headings };
 }
 
 // 前後ナビ（非同期ラッパー）


### PR DESCRIPTION
## Summary
- scope TOC scanning to post body and auto-slug headings
- expose parsed headings from markdown to hide empty TOC
- conditionally render mobile TOC only when headings exist

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive ESLint setup)


------
https://chatgpt.com/codex/tasks/task_b_68a0a7abfeb08323b09cdcf931a5a2e3