### PR TITLE
Extract markdown headings server-side and render TOC conditionally

### DIFF
--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -62,11 +62,13 @@ export default async function PostPage({ params }: { params: { slug: string } })
     description: post.description,
   };
 
+  const hasTOC = Array.isArray(post.headings) && post.headings.length > 0;
+
   return (
     <main className="mx-auto max-w-5xl px-4 py-8">
-      <div className="grid grid-cols-1 gap-8 md:grid-cols-12">
+      <div className={`grid grid-cols-1 gap-8 ${hasTOC ? 'md:grid-cols-12' : ''}`}>
         {/* 本文（8カラム） */}
-        <article className="md:col-span-8">
+        <article className={hasTOC ? 'md:col-span-8' : ''}>
           <header className="mb-6">
             <h1 className="text-2xl font-bold">{post.title}</h1>
             <time className="mt-2 block text-sm text-gray-500">
@@ -127,13 +129,13 @@ export default async function PostPage({ params }: { params: { slug: string } })
             </section>
           )}
 
-          {/* モバイル TOC（本文に見出しが無い場合は非表示にしたい場合のみ） */}
-          {post.headings?.length ? (
+          {/* モバイル TOC（本文に見出しが無い場合は非表示） */}
+          {hasTOC && (
             <details className="md:hidden toc-mobile mt-10">
               <summary className="toc-mobile-summary">目次</summary>
               <TableOfContents headings={post.headings} />
             </details>
-          ) : null}
+          )}
 
           <script
             type="application/ld+json"
@@ -141,12 +143,14 @@ export default async function PostPage({ params }: { params: { slug: string } })
           />
         </article>
 
-        {/* ▼ デスクトップ用（ここが空になっていた） */}
-        <aside className="hidden md:block md:col-span-4">
-          <div className="sticky top-24">
-            <TableOfContents headings={post.headings} />
-          </div>
-        </aside>
+        {/* ▼ デスクトップ用 */}
+        {hasTOC && (
+          <aside className="hidden md:block md:col-span-4">
+            <div className="sticky top-24">
+              <TableOfContents headings={post.headings} />
+            </div>
+          </aside>
+        )}
       </div>
     </main>
   );

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -7,6 +7,41 @@ import { renderMarkdown } from "./markdown";
 const POSTS_DIR = path.join(process.cwd(), "posts");
 const MD_REGEX = /\.mdx?$/i;
 
+const slugify = (s) =>
+  s.trim().toLowerCase().replace(/\s+/g, '-').replace(/[^\w\-]/g, '');
+
+function extractHeadingsFromMarkdown(md) {
+  const lines = md.split('\n');
+  const hs = [];
+  for (const line of lines) {
+    const m2 = line.match(/^##\s+(.+)/);
+    const m3 = line.match(/^###\s+(.+)/);
+    if (m2) hs.push({ depth: 2, text: m2[1].trim(), id: slugify(m2[1]) });
+    if (m3) hs.push({ depth: 3, text: m3[1].trim(), id: slugify(m3[1]) });
+  }
+  return hs;
+}
+
+// HTML文字列の <h2>/<h3> に id を埋め込む（同じslugなら上書き）
+function injectIdsToHtmlHeadings(html, headings) {
+  let out = html;
+  for (const h of headings) {
+    if (h.depth === 2) {
+      out = out.replace(
+        new RegExp(`<h2>(\\s*?)${h.text.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&')}(\\s*?)<\/h2>`),
+        `<h2 id="${h.id}">$1${h.text}$2</h2>`
+      );
+    }
+    if (h.depth === 3) {
+      out = out.replace(
+        new RegExp(`<h3>(\\s*?)${h.text.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&')}(\\s*?)<\/h3>`),
+        `<h3 id="${h.id}">$1${h.text}$2</h3>`
+      );
+    }
+  }
+  return out;
+}
+
 // posts/ 内のMarkdownファイル一覧を取得（READMEと"_"始まりは無視）
 function listPostFiles() {
   if (!fs.existsSync(POSTS_DIR)) return [];
@@ -108,8 +143,11 @@ export function getAllSlugs() {
 export async function getPostBySlug(slug) {
   const p = getPost(slug);
   if (!p) return null;
-  const { html, headings } = await renderMarkdown(p.content);
-  return { ...p, html, headings };
+  const md = p.content;
+  const headings = extractHeadingsFromMarkdown(md);
+  const { html } = await renderMarkdown(md);
+  const htmlWithIds = injectIdsToHtmlHeadings(html, headings);
+  return { ...p, html: htmlWithIds, headings };
 }
 
 // 前後ナビ（非同期ラッパー）


### PR DESCRIPTION
## Summary
- extract `##`/`###` headings in `lib/posts.js` with ids and expose as `post.headings`
- render blog post layout in one column when no headings are present

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68a0accf26e883238311a447e6f2882f