### PR TITLE
feat: enhance toc generation and layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -455,6 +455,12 @@ h1.page-title{ font-size:clamp(28px,5vw,40px); line-height:1.2; margin:24px 0 8p
   transform: translateY(0);
 }
 /* 目次 */
+/* 右サイド：中に .toc が無ければ非表示 */
+@supports (selector(:has(*))) {
+  .toc-aside:not(:has(.toc)) {
+    display: none;
+  }
+}
 .toc { width: 100%; font-size: 0.95rem; line-height: 1.75; color: #334155; }
 .toc ol { list-style: none; padding-left: 0; margin: 0; }
 .toc-li { margin: .2rem 0; }

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -62,13 +62,13 @@ export default async function PostPage({ params }: { params: { slug: string } })
     description: post.description,
   };
 
-  const hasTOC = Array.isArray(post.headings) && post.headings.length > 0;
+  const hasTOC = Array.isArray(post.headings) && post.headings.length > 0; // 使わなくてもOK（残しても可）
 
   return (
     <main className="mx-auto max-w-5xl px-4 py-8">
-      <div className={`grid grid-cols-1 gap-8 ${hasTOC ? 'md:grid-cols-12' : ''}`}>
+      <div className={`grid grid-cols-1 gap-8 md:grid-cols-12`}>
         {/* 本文（8カラム） */}
-        <article className={hasTOC ? 'md:col-span-8' : ''}>
+        <article className="md:col-span-8">
           <header className="mb-6">
             <h1 className="text-2xl font-bold">{post.title}</h1>
             <time className="mt-2 block text-sm text-gray-500">
@@ -144,13 +144,11 @@ export default async function PostPage({ params }: { params: { slug: string } })
         </article>
 
         {/* ▼ デスクトップ用 */}
-        {hasTOC && (
-          <aside className="hidden md:block md:col-span-4">
-            <div className="sticky top-24">
-              <TableOfContents headings={post.headings} />
-            </div>
-          </aside>
-        )}
+        <aside className="hidden md:block md:col-span-4">
+          <div className="sticky top-24 toc-aside">
+            <TableOfContents headings={post.headings} />
+          </div>
+        </aside>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- expand TableOfContents to build headings from document lists when none provided and highlight current section
- always render desktop TOC column with CSS-based hiding when empty
- add :has selector CSS to hide empty TOC sidebar and include TOC styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(requires interactive ESLint configuration and did not run)*

------
https://chatgpt.com/codex/tasks/task_b_68a0b101afb48323830bb8e63e97db6a