### PR TITLE
Add eslint dev dependency and fix OG image route constants

### DIFF
--- a/app/og/[slug]/route.tsx
+++ b/app/og/[slug]/route.tsx
@@ -1,15 +1,11 @@
 import { ImageResponse } from 'next/server';
 
 export const runtime = 'edge';
-export const size = { width: 1200, height: 630 };
-export const contentType = 'image/png';
 
-const BRAND = {
-  bg: '#F8FAFC',        // 背景
-  fg: '#60A5FA',        // アクセント（ライトブルー）
-  text: '#0F172A',      // 濃い文字
-  sub: '#334155',       // サブ文字
-};
+const OG_WIDTH = 1200;
+const OG_HEIGHT = 630;
+
+const BRAND = { bg: '#F8FAFC', fg: '#60A5FA', text: '#0F172A', sub: '#334155' };
 
 function abs(base: string, u?: string) {
   if (!u) return '';
@@ -19,7 +15,7 @@ function abs(base: string, u?: string) {
 export async function GET(req: Request, { params }: { params: { slug: string } }) {
   const origin = process.env.NEXT_PUBLIC_SITE_URL || new URL(req.url).origin;
 
-  // Node ランタイムのメタAPIを叩いて記事情報を取得
+  // Node ランタイムのメタAPIから記事情報を取得
   const res = await fetch(`${origin}/api/post-meta/${params.slug}`, { cache: 'no-store' });
   const meta = res.ok ? await res.json() : null;
 
@@ -28,92 +24,46 @@ export async function GET(req: Request, { params }: { params: { slug: string } }
   const thumb = abs(origin, meta?.ogImage || meta?.thumb);
   const mascot = `${origin}/otoron.webp`;
 
-  // 背景用のサムネ（任意）
-  const bgImage = thumb ? (
-    // ImageResponse は <img> の外部URLを解決可能（絶対URL必須）
-    <img
-      src={thumb}
-      width={1200}
-      height={630}
-      style={{
-        position: 'absolute',
-        inset: 0,
-        objectFit: 'cover',
-        opacity: 0.12,
-        filter: 'grayscale(20%)',
-      }}
-    />
-  ) : null;
-
   return new ImageResponse(
     (
       <div
         style={{
-          width: size.width,
-          height: size.height,
+          width: OG_WIDTH,
+          height: OG_HEIGHT,
           display: 'flex',
           flexDirection: 'column',
-          background: BRAND.bg,
           position: 'relative',
+          background: BRAND.bg,
           padding: 48,
         }}
       >
-        {bgImage}
+        {thumb ? (
+          <img
+            src={thumb}
+            width={OG_WIDTH}
+            height={OG_HEIGHT}
+            style={{ position: 'absolute', inset: 0, objectFit: 'cover', opacity: 0.12, filter: 'grayscale(20%)' }}
+          />
+        ) : null}
 
-        {/* 右上マスコット */}
         <div style={{ position: 'absolute', top: 28, right: 28, width: 96, height: 96 }}>
           <img src={mascot} width={96} height={96} style={{ objectFit: 'contain' }} />
         </div>
 
-        {/* アクセント帯 */}
-        <div
-          style={{
-            position: 'absolute',
-            left: 0,
-            bottom: 0,
-            width: '100%',
-            height: 12,
-            background: BRAND.fg,
-          }}
-        />
+        <div style={{ position: 'absolute', left: 0, bottom: 0, width: '100%', height: 12, background: BRAND.fg }} />
 
-        {/* テキスト */}
-        <div
-          style={{
-            marginTop: 12,
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 24,
-          }}
-        >
-          <div
-            style={{
-              fontSize: 56,
-              lineHeight: 1.25,
-              color: BRAND.text,
-              fontWeight: 800,
-              maxWidth: 1000,
-              letterSpacing: '-0.5px',
-              whiteSpace: 'pre-wrap',
-            }}
-          >
+        <div style={{ marginTop: 12, display: 'flex', flexDirection: 'column', gap: 24 }}>
+          <div style={{ fontSize: 56, lineHeight: 1.25, color: BRAND.text, fontWeight: 800, maxWidth: 1000, letterSpacing: '-0.5px', whiteSpace: 'pre-wrap' }}>
             {title}
           </div>
-          <div
-            style={{
-              fontSize: 28,
-              lineHeight: 1.5,
-              color: BRAND.sub,
-              maxWidth: 1000,
-              whiteSpace: 'pre-wrap',
-            }}
-          >
+          <div style={{ fontSize: 28, lineHeight: 1.5, color: BRAND.sub, maxWidth: 1000, whiteSpace: 'pre-wrap' }}>
             {description}
           </div>
           <div style={{ marginTop: 8, fontSize: 22, color: BRAND.sub }}>OTORON BLOG</div>
         </div>
       </div>
     ),
-    { ...size }
+    { width: OG_WIDTH, height: OG_HEIGHT }
   );
 }
+

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@types/node": "24.3.0",
     "@types/react": "19.1.10",
+    "eslint": "^8.57.0",
     "rehype-autolink-headings": "^7.1.0",
     "rehype-external-links": "^3.0.0",
     "rehype-sanitize": "^6.0.0",


### PR DESCRIPTION
## Summary
- add eslint to devDependencies
- refactor OG image route to remove invalid exports and pass width/height as local constants

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: unknown option '--no-error-on-unmatched-pattern')
- `npx next lint` (fails: ESLint must be installed)


------
https://chatgpt.com/codex/tasks/task_b_68a1a385176483238b31c12450af32ed