### PR TITLE
fix: update OG route import and add lint config

### DIFF
--- a/app/og/[slug]/route.tsx
+++ b/app/og/[slug]/route.tsx
@@ -1,4 +1,4 @@
-import { ImageResponse } from 'next/server';
+import { ImageResponse } from 'next/og';
 
 export const runtime = 'edge';
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/node": "24.3.0",
     "@types/react": "19.1.10",
     "eslint": "^8.57.0",
+    "eslint-config-next": "14.2.5",
     "rehype-autolink-headings": "^7.1.0",
     "rehype-external-links": "^3.0.0",
     "rehype-sanitize": "^6.0.0",


### PR DESCRIPTION
## Summary
- fix OG image generation route to import `ImageResponse` from `next/og`
- add `eslint-config-next` to dev dependencies

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found; dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68a1a781f4148323be601dc60ab0b85b