### PR TITLE
Add tagging system and tag pages

### DIFF
--- a/app/blog/tags/[tag]/page.tsx
+++ b/app/blog/tags/[tag]/page.tsx
@@ -1,0 +1,39 @@
+export const runtime = "nodejs";
+import PostCard from "@/components/PostCard";
+import { getAllTags, getPostsByTag, getTagName } from "@/lib/tags";
+
+export async function generateStaticParams() {
+  const tags = await getAllTags();
+  return tags.map((t) => ({ tag: t.slug }));
+}
+
+export async function generateMetadata({ params }: { params: { tag: string } }) {
+  const name = await getTagName(params.tag);
+  return {
+    title: `「${name}」の記事 | オトロン公式ブログ`,
+    description: `タグ「${name}」の記事一覧です。`,
+    alternates: { canonical: `/blog/tags/${params.tag}` },
+  };
+}
+
+export default async function TagPage({ params }: { params: { tag: string } }) {
+  const posts = await getPostsByTag(params.tag);
+  const name = await getTagName(params.tag);
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-8">
+      <h1 className="text-xl font-semibold">タグ: {name}</h1>
+      <div className="mt-4 grid grid-cols-1 gap-6 sm:grid-cols-2">
+        {posts.map((p: any) => (
+          <PostCard
+            key={p.slug}
+            slug={p.slug}
+            title={p.title}
+            description={p.description}
+            date={p.date}
+            thumb={p.thumb}
+          />
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/app/blog/tags/page.tsx
+++ b/app/blog/tags/page.tsx
@@ -1,0 +1,28 @@
+export const runtime = "nodejs";
+import Link from "next/link";
+import { getAllTags } from "@/lib/tags";
+
+export const metadata = {
+  title: "トピック一覧 | オトロン公式ブログ",
+  description: "タグ別に記事を探せます。",
+  alternates: { canonical: "/blog/tags" },
+};
+
+export default async function TagsIndex() {
+  const tags = await getAllTags();
+  return (
+    <main className="mx-auto max-w-3xl px-4 py-8">
+      <h1 className="text-xl font-semibold">トピック</h1>
+      <ul className="mt-4 flex flex-wrap gap-2">
+        {tags.map((t) => (
+          <li key={t.slug}>
+            <Link href={`/blog/tags/${t.slug}`} className="tag-chip">
+              {t.name}
+              <span className="ml-1 text-gray-500">({t.count})</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -473,3 +473,14 @@ h1.page-title{ font-size:clamp(28px,5vw,40px); line-height:1.2; margin:24px 0 8p
 /* 見出しのアンカーずれ対策（ヘッダー分の余白） */
 article h2, article h3 { scroll-margin-top: 96px; }
 
+.tag-chip {
+  display: inline-block;
+  padding: .25rem .6rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 9999px;
+  background: #fff;
+  font-size: .85rem;
+  line-height: 1;
+}
+.tag-chip:hover { background: #f8fafc; }
+

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -6,6 +6,7 @@ import {
   getAdjacentPosts,
   getRelatedPosts,
 } from "@/lib/posts";
+import { tagSlug } from "@/lib/tags";
 import PostCard from "@/components/PostCard";
 import TableOfContents from "@/components/TableOfContents";
 
@@ -86,6 +87,18 @@ export default async function PostPage({ params }: { params: { slug: string } })
               />
             </div>
           </header>
+
+          {post.tags?.length > 0 && (
+            <ul className="mt-3 flex flex-wrap gap-2">
+              {post.tags.map((t: string) => (
+                <li key={t}>
+                  <a href={`/blog/tags/${tagSlug(t)}`} className="tag-chip">
+                    {t}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          )}
 
           <div id="post-body" className="prose prose-blue max-w-none">
             <div dangerouslySetInnerHTML={{ __html: post.html }} />

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { headers } from 'next/headers';
 import { getAllPostsMeta } from '@/lib/posts';
+import { getAllTags } from '@/lib/tags';
 
 export const runtime = 'nodejs';
 
@@ -15,14 +16,19 @@ function siteBase() {
 export async function GET() {
   const SITE = siteBase();
   const posts = (await getAllPostsMeta() as any[]).filter((p: any) => !p.draft);
+  const tags = await getAllTags();
+  const nowISO = new Date().toISOString();
 
   const urls = [
-    { loc: `${SITE}/blog`, lastmod: new Date().toISOString() },
+    { loc: `${SITE}/blog`, lastmod: nowISO },
     ...posts.map((p: any) => ({
       loc: `${SITE}/blog/posts/${p.slug}`,
       lastmod: new Date(p.date).toISOString(),
     })),
   ];
+  for (const t of tags) {
+    urls.push({ loc: `${SITE}/blog/tags/${t.slug}`, lastmod: nowISO });
+  }
 
   const body = `<?xml version="1.0" encoding="UTF-8"?>
   <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -10,6 +10,15 @@ const MD_REGEX = /\.mdx?$/i;
 const slugify = (s) =>
   s.trim().toLowerCase().replace(/\s+/g, '-').replace(/[^\w\-]/g, '');
 
+const normalizeTags = (tags) => {
+  if (!tags) return [];
+  if (Array.isArray(tags)) return tags.map(String).map((s) => s.trim()).filter(Boolean);
+  return String(tags)
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+};
+
 function extractHeadingsFromMarkdown(md) {
   const lines = md.split('\n');
   const hs = [];
@@ -69,6 +78,8 @@ function readPost(file) {
   const p = { slug, content, ...data };
   assertFrontMatter(p);
 
+  p.tags = normalizeTags(data.tags);
+
   // 日付を YYYY-MM-DD 文字列へ正規化（不正ならそのまま文字列）
   const d = new Date(p.date);
   p.date = isNaN(d) ? String(p.date) : d.toISOString().slice(0, 10);
@@ -90,6 +101,8 @@ function readPostMeta(file) {
 
   const p = { slug, ...data };
   assertFrontMatter(p);
+
+  p.tags = normalizeTags(data.tags);
 
   // 日付を YYYY-MM-DD 文字列へ正規化（不正ならそのまま文字列）
   const d = new Date(p.date);
@@ -157,35 +170,33 @@ export async function getAdjacentPosts(slug) {
 
 // 関連記事を取得
 export async function getRelatedPosts(slug, limit = 2) {
-  const all = (await getAllPostsMeta()).filter(
-    (p) => !p.draft && p.slug !== slug
-  );
-
+  const all = (await getAllPostsMeta()).filter((p) => !p.draft && p.slug !== slug);
   const cur = await getPostBySlug(slug);
   if (!cur) return all.slice(0, limit);
 
+  const curTags = new Set((cur.tags ?? []).map((t) => String(t).toLowerCase()));
   const curDate = new Date(cur.date);
 
-  const sameMonth = all.filter((p) => {
-    const d = new Date(p.date);
-    return (
-      d.getFullYear() === curDate.getFullYear() &&
-      d.getMonth() === curDate.getMonth()
-    );
+  all.sort((a, b) => {
+    const score = (p) =>
+      (p.tags ?? []).reduce(
+        (s, t) => s + (curTags.has(String(t).toLowerCase()) ? 1 : 0),
+        0
+      );
+    const ta = score(b) - score(a); // 1) タグ一致数が多い順
+    if (ta !== 0) return ta;
+
+    const sameMonth = (p) => {
+      const d = new Date(p.date);
+      return d.getFullYear() === curDate.getFullYear() && d.getMonth() === curDate.getMonth();
+    };
+    const mb = Number(sameMonth(b)) - Number(sameMonth(a)); // 2) 同月優先
+    if (mb !== 0) return mb;
+
+    const da = Math.abs(new Date(a.date) - curDate); // 3) 近い順
+    const db = Math.abs(new Date(b.date) - curDate);
+    return da - db;
   });
 
-  let result = sameMonth.slice(0, limit);
-
-  if (result.length < limit) {
-    const rest = all
-      .filter((p) => !result.find((r) => r.slug === p.slug))
-      .sort(
-        (a, b) =>
-          Math.abs(new Date(a.date).getTime() - curDate.getTime()) -
-          Math.abs(new Date(b.date).getTime() - curDate.getTime())
-      );
-    result = result.concat(rest.slice(0, limit - result.length));
-  }
-
-  return result;
+  return all.slice(0, limit);
 }

--- a/lib/tags.ts
+++ b/lib/tags.ts
@@ -1,0 +1,42 @@
+import { getAllPostsMeta } from "@/lib/posts";
+
+export function tagSlug(s: string) {
+  return s
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^\w\-ぁ-んァ-ヴー一-龠]/g, ""); // 日本語も許容
+}
+
+export async function getAllTags() {
+  const posts = (await getAllPostsMeta()).filter((p) => !p.draft);
+  const acc = new Map<string, { slug: string; name: string; count: number }>();
+  for (const p of posts) {
+    for (const t of p.tags ?? []) {
+      const slug = tagSlug(t);
+      const cur = acc.get(slug);
+      if (cur) cur.count += 1;
+      else acc.set(slug, { slug, name: t, count: 1 });
+    }
+  }
+  return Array.from(acc.values()).sort(
+    (a, b) => b.count - a.count || a.slug.localeCompare(b.slug)
+  );
+}
+
+export async function getPostsByTag(tagOrSlug: string) {
+  const slug = tagSlug(tagOrSlug);
+  const posts = (await getAllPostsMeta())
+    .filter(
+      (p) =>
+        !p.draft &&
+        (p.tags ?? []).some((t: string) => tagSlug(t) === slug)
+    )
+    .sort((a, b) => (a.date < b.date ? 1 : -1));
+  return posts;
+}
+
+export async function getTagName(slug: string) {
+  const hit = (await getAllTags()).find((t) => t.slug === slug);
+  return hit?.name ?? slug;
+}


### PR DESCRIPTION
## Summary
- allow tags in post frontmatter and tag-weighted related articles
- add tag utilities and listing pages with tag chips
- include tag links in sitemap and post pages

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a1c4cfc4708323a5c52d8760139c7f