### PR TITLE
Improve tag utilities with TypeScript safety

### DIFF
--- a/app/og/[slug]/route.tsx
+++ b/app/og/[slug]/route.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/next/no-img-element, jsx-a11y/alt-text */
 import { ImageResponse } from 'next/og';
 
 export const runtime = 'edge';
@@ -42,12 +43,13 @@ export async function GET(req: Request, { params }: { params: { slug: string } }
             src={thumb}
             width={OG_WIDTH}
             height={OG_HEIGHT}
+            alt=""
             style={{ position: 'absolute', inset: 0, objectFit: 'cover', opacity: 0.12, filter: 'grayscale(20%)' }}
           />
         ) : null}
 
         <div style={{ position: 'absolute', top: 28, right: 28, width: 96, height: 96 }}>
-          <img src={mascot} width={96} height={96} style={{ objectFit: 'contain' }} />
+          <img src={mascot} width={96} height={96} alt="OTORON" style={{ objectFit: 'contain' }} />
         </div>
 
         <div style={{ position: 'absolute', left: 0, bottom: 0, width: '100%', height: 12, background: BRAND.fg }} />

--- a/lib/tags.ts
+++ b/lib/tags.ts
@@ -1,42 +1,52 @@
 import { getAllPostsMeta } from "@/lib/posts";
 
+type PostMeta = {
+  slug: string;
+  title?: string;
+  description?: string;
+  date?: string;
+  draft?: boolean;
+  tags?: string[];
+};
+
 export function tagSlug(s: string) {
   return s
     .trim()
     .toLowerCase()
     .replace(/\s+/g, "-")
-    .replace(/[^\w\-ぁ-んァ-ヴー一-龠]/g, ""); // 日本語も許容
+    .replace(/[^\w\-ぁ-んァ-ヴー一-龠]/g, "");
 }
 
 export async function getAllTags() {
-  const posts = (await getAllPostsMeta()).filter((p) => !p.draft);
+  const posts = (await getAllPostsMeta() as unknown as PostMeta[])
+    .filter(p => !p.draft);
+
   const acc = new Map<string, { slug: string; name: string; count: number }>();
   for (const p of posts) {
-    for (const t of p.tags ?? []) {
+    const tags = Array.isArray(p.tags) ? p.tags : [];
+    for (const t of tags) {
       const slug = tagSlug(t);
       const cur = acc.get(slug);
       if (cur) cur.count += 1;
       else acc.set(slug, { slug, name: t, count: 1 });
     }
   }
-  return Array.from(acc.values()).sort(
-    (a, b) => b.count - a.count || a.slug.localeCompare(b.slug)
-  );
+  return Array.from(acc.values())
+    .sort((a, b) => b.count - a.count || a.slug.localeCompare(b.slug));
 }
 
 export async function getPostsByTag(tagOrSlug: string) {
   const slug = tagSlug(tagOrSlug);
-  const posts = (await getAllPostsMeta())
-    .filter(
-      (p) =>
-        !p.draft &&
-        (p.tags ?? []).some((t: string) => tagSlug(t) === slug)
+  const posts = (await getAllPostsMeta() as unknown as PostMeta[])
+    .filter(p =>
+      !p.draft &&
+      (Array.isArray(p.tags) ? p.tags : []).some(t => tagSlug(t) === slug)
     )
-    .sort((a, b) => (a.date < b.date ? 1 : -1));
+    .sort((a, b) => (a.date ?? "") < (b.date ?? "") ? 1 : -1);
   return posts;
 }
 
 export async function getTagName(slug: string) {
-  const hit = (await getAllTags()).find((t) => t.slug === slug);
+  const hit = (await getAllTags()).find(t => t.slug === slug);
   return hit?.name ?? slug;
 }


### PR DESCRIPTION
## Summary
- define PostMeta type and safely access `draft` and `tags`
- disable Next.js `<img>` lint rule and add alt text in OG image route

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found; dependency install forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68a1d220fc708323a6f1029e1bfb202b