### PR TITLE
Improve blog structured data and sharing features

### DIFF
--- a/app/blog/tags/[tag]/page.tsx
+++ b/app/blog/tags/[tag]/page.tsx
@@ -19,8 +19,23 @@ export async function generateMetadata({ params }: { params: { tag: string } }) 
 export default async function TagPage({ params }: { params: { tag: string } }) {
   const posts = await getPostsByTag(params.tag);
   const name = await getTagName(params.tag);
+  const itemListLd = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: `タグ: ${name}`,
+    itemListElement: posts.map((p: any, i: number) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      url: `/blog/posts/${p.slug}`,
+      name: p.title,
+    })),
+  };
   return (
     <main className="mx-auto max-w-5xl px-4 py-8">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListLd) }}
+      />
       <h1 className="text-xl font-semibold">タグ: {name}</h1>
       <div className="mt-4 grid grid-cols-1 gap-6 sm:grid-cols-2">
         {posts.map((p: any) => (

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -9,6 +9,7 @@ import {
 import { tagSlug } from "@/lib/tags";
 import PostCard from "@/components/PostCard";
 import TableOfContents from "@/components/TableOfContents";
+import CopyLink from "@/components/CopyLink";
 
 const BASE = "https://playotoron.com";
 const FALLBACK_THUMB = "/otolon_face.webp";
@@ -35,7 +36,12 @@ export async function generateMetadata({ params }: { params: { slug: string } })
       url,
       title,
       description: p.description,
-      images: [{ url: ogAuto, width: 1200, height: 630 }],
+      images: [{
+        url: ogAuto,
+        width: 1200,
+        height: 630,
+        alt: `${p.title} | オトロン公式ブログ`,
+      }],
       locale: "ja_JP",
       publishedTime: p.date,
       modifiedTime: p.updated ?? p.date,
@@ -64,6 +70,19 @@ export default async function PostPage({ params }: { params: { slug: string } })
     description: post.description,
     timeRequired: post.readingMinutes ? `PT${post.readingMinutes}M` : undefined,
   };
+  const breadcrumbLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "ブログ", item: `${BASE}/blog` },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: post.title,
+        item: `${BASE}${canonical}`,
+      },
+    ],
+  };
 
   const hasTOC = Array.isArray(post.headings) && post.headings.length > 0; // 使わなくてもOK（残しても可）
 
@@ -74,14 +93,27 @@ export default async function PostPage({ params }: { params: { slug: string } })
         <article className="md:col-span-8">
           <header className="mb-6">
             <h1 className="text-2xl font-bold">{post.title}</h1>
-            <time className="mt-2 block text-sm text-gray-500">
-              {new Date(post.date).toLocaleDateString('ja-JP')}
-            </time>
+            <div className="mt-1 text-xs text-gray-500 space-x-2">
+              <time dateTime={post.date}>
+                公開: {new Date(post.date).toLocaleDateString('ja-JP')}
+              </time>
+              {post.updated && post.updated !== post.date && (
+                <span>
+                  ／ 更新:{" "}
+                  <time dateTime={post.updated}>
+                    {new Date(post.updated).toLocaleDateString('ja-JP')}
+                  </time>
+                </span>
+              )}
+            </div>
             {typeof post.readingMinutes === 'number' && (
               <span className="mt-1 inline-block text-xs text-gray-500">
                 約 {post.readingMinutes} 分で読めます
               </span>
             )}
+            <div className="mt-2">
+              <CopyLink url={`${BASE}${canonical}`} />
+            </div>
             <div className="relative mt-4 aspect-[16/9] w-full overflow-hidden rounded-xl border border-gray-100">
               <Image
                 src={hero}
@@ -161,6 +193,10 @@ export default async function PostPage({ params }: { params: { slug: string } })
           <script
             type="application/ld+json"
             dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+          />
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
           />
         </article>
 

--- a/components/CopyLink.tsx
+++ b/components/CopyLink.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { useState } from 'react';
+
+export default function CopyLink({ url }: { url: string }) {
+  const [ok, setOk] = useState(false);
+  return (
+    <button
+      onClick={async () => {
+        try {
+          await navigator.clipboard.writeText(url);
+          setOk(true);
+          setTimeout(() => setOk(false), 1500);
+        } catch {}
+      }}
+      className="rounded-full border px-3 py-1 text-xs text-gray-600 hover:bg-gray-50"
+      aria-label="記事URLをコピー"
+    >
+      {ok ? 'コピーしました' : 'リンクをコピー'}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- show both publish and update dates on posts and add copy-link button
- include breadcrumb metadata for posts and ItemList metadata for tag pages
- add `og:image:alt` metadata for posts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/eslint)*

------
https://chatgpt.com/codex/tasks/task_b_68a2f6f56398832398e88a37c708f6ee