### PR TITLE
feat: improve copy link component

### DIFF
--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -11,7 +11,7 @@ import PostCard from "@/components/PostCard";
 import TableOfContents from "@/components/TableOfContents";
 import CopyLink from "@/components/CopyLink";
 
-const BASE = "https://playotoron.com";
+const BASE = process.env.NEXT_PUBLIC_SITE_URL || "https://playotoron.com";
 const FALLBACK_THUMB = "/otolon_face.webp";
 
 export async function generateStaticParams() {

--- a/components/CopyLink.tsx
+++ b/components/CopyLink.tsx
@@ -1,21 +1,71 @@
 'use client';
 import { useState } from 'react';
 
-export default function CopyLink({ url }: { url: string }) {
-  const [ok, setOk] = useState(false);
+export default function CopyLink({ url, className = '' }: { url: string; className?: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function doCopy() {
+    const text = String(url || '');
+    try {
+      // 1) 標準 API
+      await navigator.clipboard.writeText(text);
+      done();
+    } catch {
+      // 2) フォールバック（セキュアコンテキスト外や権限NGでも動く）
+      try {
+        const ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.position = 'fixed';
+        ta.style.top = '-1000px';
+        ta.style.opacity = '0';
+        document.body.appendChild(ta);
+        ta.focus();
+        ta.select();
+        document.execCommand('copy');
+        document.body.removeChild(ta);
+        done();
+      } catch {
+        // 最後の保険（明示フィードバック）
+        window.prompt('リンクをコピーできませんでした。下のテキストをコピーしてください。', text);
+      }
+    }
+  }
+
+  function done() {
+    setCopied(true);
+    const t = setTimeout(() => setCopied(false), 1500);
+    // GC されにくいケース用
+    return () => clearTimeout(t);
+  }
+
   return (
     <button
-      onClick={async () => {
-        try {
-          await navigator.clipboard.writeText(url);
-          setOk(true);
-          setTimeout(() => setOk(false), 1500);
-        } catch {}
-      }}
-      className="rounded-full border px-3 py-1 text-xs text-gray-600 hover:bg-gray-50"
-      aria-label="記事URLをコピー"
+      type="button"
+      onClick={doCopy}
+      aria-live="polite"
+      className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs transition
+                  border-gray-300 text-gray-700 hover:bg-blue-50 hover:border-blue-300 active:translate-y-[1px]
+                  focus:outline-none focus:ring-2 focus:ring-blue-300/60 ${className}`}
     >
-      {ok ? 'コピーしました' : 'リンクをコピー'}
+      {/* コピー前アイコン */}
+      <svg
+        viewBox="0 0 24 24"
+        className={`h-3.5 w-3.5 ${copied ? 'hidden' : ''}`}
+        aria-hidden="true"
+      >
+        <path fill="currentColor" d="M16 1H6a2 2 0 0 0-2 2v12h2V3h10V1zm3 4H10a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h9a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2zm0 16H10V7h9v14z"/>
+      </svg>
+      {/* 成功アイコン */}
+      <svg
+        viewBox="0 0 24 24"
+        className={`h-3.5 w-3.5 text-blue-600 ${copied ? '' : 'hidden'}`}
+        aria-hidden="true"
+      >
+        <path fill="currentColor" d="M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4z"/>
+      </svg>
+
+      <span>{copied ? 'コピーしました' : 'リンクをコピー'}</span>
     </button>
   );
 }
+


### PR DESCRIPTION
## Summary
- enhance CopyLink with safe clipboard fallback and feedback icons
- allow post page to use NEXT_PUBLIC_SITE_URL for canonical URLs

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/eslint)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a312a3945883238313ccab1eac6b57