### PR TITLE
Refine copy link and clean up missing thumbnails

### DIFF
--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -106,12 +106,12 @@ export default async function PostPage({ params }: { params: { slug: string } })
                 </span>
               )}
             </div>
-            {typeof post.readingMinutes === 'number' && (
-              <span className="mt-1 inline-block text-xs text-gray-500">
-                約 {post.readingMinutes} 分で読めます
-              </span>
-            )}
-            <div className="mt-2">
+            <div className="mt-1 flex items-center gap-2">
+              {typeof post.readingMinutes === 'number' && (
+                <span className="text-xs text-gray-500">
+                  約 {post.readingMinutes} 分で読めます
+                </span>
+              )}
               <CopyLink url={`${BASE}${canonical}`} />
             </div>
             <div className="relative mt-4 aspect-[16/9] w-full overflow-hidden rounded-xl border border-gray-100">

--- a/components/CopyLink.tsx
+++ b/components/CopyLink.tsx
@@ -1,41 +1,41 @@
 'use client';
 import { useState } from 'react';
 
-export default function CopyLink({ url, className = '' }: { url: string; className?: string }) {
+export default function CopyLink({
+  url,
+  className = '',
+}: { url: string; className?: string }) {
   const [copied, setCopied] = useState(false);
 
   async function doCopy() {
     const text = String(url || '');
     try {
-      // 1) 標準 API
+      // 標準API
       await navigator.clipboard.writeText(text);
       done();
     } catch {
-      // 2) フォールバック（セキュアコンテキスト外や権限NGでも動く）
+      // フォールバック（非HTTPS/権限NGでも可）
       try {
         const ta = document.createElement('textarea');
         ta.value = text;
+        ta.setAttribute('readonly', '');
         ta.style.position = 'fixed';
         ta.style.top = '-1000px';
-        ta.style.opacity = '0';
         document.body.appendChild(ta);
-        ta.focus();
         ta.select();
         document.execCommand('copy');
         document.body.removeChild(ta);
         done();
       } catch {
-        // 最後の保険（明示フィードバック）
-        window.prompt('リンクをコピーできませんでした。下のテキストをコピーしてください。', text);
+        // 最後の保険
+        window.prompt('コピーできませんでした。下のテキストをコピーしてください。', text);
       }
     }
   }
 
   function done() {
     setCopied(true);
-    const t = setTimeout(() => setCopied(false), 1500);
-    // GC されにくいケース用
-    return () => clearTimeout(t);
+    setTimeout(() => setCopied(false), 1500);
   }
 
   return (
@@ -43,29 +43,24 @@ export default function CopyLink({ url, className = '' }: { url: string; classNa
       type="button"
       onClick={doCopy}
       aria-live="polite"
-      className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs transition
-                  border-gray-300 text-gray-700 hover:bg-blue-50 hover:border-blue-300 active:translate-y-[1px]
-                  focus:outline-none focus:ring-2 focus:ring-blue-300/60 ${className}`}
+      // not-prose で typography の巨大化を遮断。サイズを強制。
+      className={`not-prose inline-flex items-center gap-1 rounded-full border
+                  px-2 py-1 text-[12px] leading-none
+                  border-gray-300 text-gray-700
+                  hover:bg-blue-50 hover:border-blue-300
+                  active:translate-y-[1px] focus:outline-none focus:ring-2 focus:ring-blue-300/60
+                  ${className}`}
     >
       {/* コピー前アイコン */}
-      <svg
-        viewBox="0 0 24 24"
-        className={`h-3.5 w-3.5 ${copied ? 'hidden' : ''}`}
-        aria-hidden="true"
-      >
+      <svg viewBox="0 0 24 24" className={`w-3.5 h-3.5 shrink-0 ${copied ? 'hidden' : ''}`} aria-hidden="true">
         <path fill="currentColor" d="M16 1H6a2 2 0 0 0-2 2v12h2V3h10V1zm3 4H10a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h9a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2zm0 16H10V7h9v14z"/>
       </svg>
       {/* 成功アイコン */}
-      <svg
-        viewBox="0 0 24 24"
-        className={`h-3.5 w-3.5 text-blue-600 ${copied ? '' : 'hidden'}`}
-        aria-hidden="true"
-      >
+      <svg viewBox="0 0 24 24" className={`w-3.5 h-3.5 shrink-0 text-blue-600 ${copied ? '' : 'hidden'}`} aria-hidden="true">
         <path fill="currentColor" d="M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4z"/>
       </svg>
 
-      <span>{copied ? 'コピーしました' : 'リンクをコピー'}</span>
+      <span className="select-none">{copied ? 'コピーしました' : 'リンクをコピー'}</span>
     </button>
   );
 }
-

--- a/posts/compare-apps.md
+++ b/posts/compare-apps.md
@@ -2,7 +2,6 @@
 title: "音感アプリの選び方：幼児向けに大事な3条件"
 date: "2025-08-15"
 description: "幼児に向くUIと音の品質、記録機能の3点でチェック。"
-thumb: "/thumbs/compare-apps.jpg"
 ogImage: "/ogp.png"
 tags: ["アプリ比較", "幼児"]
 ---

--- a/posts/first-post.md
+++ b/posts/first-post.md
@@ -2,7 +2,6 @@
 title: "3歳からできる音感トレーニングの始め方"
 date: "2025-08-15"
 description: "幼児期に無理なく耳を育てるための具体ステップ。家庭とアプリの両輪で。"
-thumb: "/thumbs/first-post.jpg"
 ogImage: "/ogp.png"
 tags: ["絶対音感", "幼児", "トレーニング"]
 ---


### PR DESCRIPTION
## Summary
- replace CopyLink with a smaller button that falls back to textarea copy when needed
- display reading time and copy button in a single flex row for tighter layout
- remove nonexistent thumbnail references from posts to avoid 400 errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/eslint)*

------
https://chatgpt.com/codex/tasks/task_b_68a3299c42b083238bcdc38cba20cb47