### PR TITLE
Specify hero image dimensions and secure post images

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -484,3 +484,10 @@ article h2, article h3 { scroll-margin-top: 96px; }
 }
 .tag-chip:hover { background: #f8fafc; }
 
+/* 本文(prose)内の画像がレイアウトを壊さないように */
+.prose img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 0.75rem; /* 12px 相当 */
+}
+

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -93,35 +93,31 @@ export default async function PostPage({ params }: { params: { slug: string } })
         <article className="md:col-span-8">
           <header className="mb-6">
             <h1 className="text-2xl font-bold">{post.title}</h1>
-            <div className="mt-1 text-xs text-gray-500 space-x-2">
-              <time dateTime={post.date}>
+            <div className="mt-1 flex items-center gap-2">
+              <span className="text-xs text-gray-500">
                 公開: {new Date(post.date).toLocaleDateString('ja-JP')}
-              </time>
+              </span>
               {post.updated && post.updated !== post.date && (
-                <span>
-                  ／ 更新:{" "}
-                  <time dateTime={post.updated}>
-                    {new Date(post.updated).toLocaleDateString('ja-JP')}
-                  </time>
+                <span className="text-xs text-gray-500">
+                  ／ 更新: {new Date(post.updated).toLocaleDateString('ja-JP')}
                 </span>
               )}
-            </div>
-            <div className="mt-1 flex items-center gap-2">
               {typeof post.readingMinutes === 'number' && (
                 <span className="text-xs text-gray-500">
-                  約 {post.readingMinutes} 分で読めます
+                  ／ 約 {post.readingMinutes} 分で読めます
                 </span>
               )}
               <CopyLink url={`${BASE}${canonical}`} />
             </div>
-            <div className="relative mt-4 aspect-[16/9] w-full overflow-hidden rounded-xl border border-gray-100">
+            <div className="mt-4">
               <Image
                 src={hero}
                 alt={post.title}
-                fill
+                width={1200}
+                height={630}               // 16:9相当
                 priority
                 sizes="(max-width:768px) 100vw, 720px"
-                className="object-cover"
+                className="w-full h-auto rounded-xl border border-gray-100 object-cover"
               />
             </div>
           </header>


### PR DESCRIPTION
## Summary
- Fix post hero layout by specifying image width and height and merging meta row with copy link
- Ensure images in article content scale safely
- Remove placeholder thumbnails and rely on default avatar to avoid missing assets

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a3324f46088323b9bcd91d163ffa02