### PR TITLE
feat: refine copy link component

### DIFF
--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -93,21 +93,22 @@ export default async function PostPage({ params }: { params: { slug: string } })
         <article className="md:col-span-8">
           <header className="mb-6">
             <h1 className="text-2xl font-bold">{post.title}</h1>
-            <div className="mt-1 flex items-center gap-2">
-              <span className="text-xs text-gray-500">
+            <div className="mt-1 flex items-center gap-2 text-xs text-gray-500">
+              <time dateTime={post.date}>
                 公開: {new Date(post.date).toLocaleDateString('ja-JP')}
-              </span>
+              </time>
               {post.updated && post.updated !== post.date && (
-                <span className="text-xs text-gray-500">
-                  ／ 更新: {new Date(post.updated).toLocaleDateString('ja-JP')}
+                <span>
+                  ／ 更新:{' '}
+                  <time dateTime={post.updated}>
+                    {new Date(post.updated).toLocaleDateString('ja-JP')}
+                  </time>
                 </span>
               )}
               {typeof post.readingMinutes === 'number' && (
-                <span className="text-xs text-gray-500">
-                  ／ 約 {post.readingMinutes} 分で読めます
-                </span>
+                <span>／ 約 {post.readingMinutes} 分で読めます</span>
               )}
-              <CopyLink url={`${BASE}${canonical}`} />
+              <CopyLink url={`${BASE}${canonical}`} className="ml-1" />
             </div>
             <div className="mt-4">
               <Image

--- a/components/CopyLink.tsx
+++ b/components/CopyLink.tsx
@@ -1,20 +1,26 @@
 'use client';
 import { useState } from 'react';
 
+type Variant = 'link' | 'icon'; // link=テキストリンク風, icon=アイコンだけ
+
 export default function CopyLink({
   url,
+  variant = 'link',
   className = '',
-}: { url: string; className?: string }) {
+}: {
+  url: string;
+  variant?: Variant;
+  className?: string;
+}) {
   const [copied, setCopied] = useState(false);
 
   async function doCopy() {
     const text = String(url || '');
     try {
-      // 標準API
       await navigator.clipboard.writeText(text);
-      done();
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
     } catch {
-      // フォールバック（非HTTPS/権限NGでも可）
       try {
         const ta = document.createElement('textarea');
         ta.value = text;
@@ -25,42 +31,60 @@ export default function CopyLink({
         ta.select();
         document.execCommand('copy');
         document.body.removeChild(ta);
-        done();
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
       } catch {
-        // 最後の保険
         window.prompt('コピーできませんでした。下のテキストをコピーしてください。', text);
       }
     }
   }
 
-  function done() {
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
+  // 共通アイコン
+  const Icon = ({ ok }: { ok: boolean }) => (
+    ok ? (
+      <svg viewBox="0 0 24 24" className="w-3.5 h-3.5 text-blue-600" aria-hidden="true">
+        <path fill="currentColor" d="M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4z" />
+      </svg>
+    ) : (
+      <svg viewBox="0 0 24 24" className="w-3.5 h-3.5" aria-hidden="true">
+        <path
+          fill="currentColor"
+          d="M16 1H6a2 2 0 0 0-2 2v12h2V3h10V1zm3 4H10a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h9a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2zm0 16H10V7h9v14z"
+        />
+      </svg>
+    )
+  );
+
+  if (variant === 'icon') {
+    // アイコンだけ（さらに小さく）
+    return (
+      <button
+        type="button"
+        onClick={doCopy}
+        aria-label={copied ? 'コピーしました' : 'リンクをコピー'}
+        className={`not-prose inline-flex h-5 w-5 items-center justify-center rounded-md
+                    text-gray-500 hover:text-blue-600 focus:outline-none focus:ring-1 focus:ring-blue-300/70
+                    ${className}`}
+      >
+        <Icon ok={copied} />
+      </button>
+    );
   }
 
+  // デフォルト：テキストリンク風（極小）
   return (
     <button
       type="button"
       onClick={doCopy}
       aria-live="polite"
-      // not-prose で typography の巨大化を遮断。サイズを強制。
-      className={`not-prose inline-flex items-center gap-1 rounded-full border
-                  px-2 py-1 text-[12px] leading-none
-                  border-gray-300 text-gray-700
-                  hover:bg-blue-50 hover:border-blue-300
-                  active:translate-y-[1px] focus:outline-none focus:ring-2 focus:ring-blue-300/60
+      className={`not-prose inline-flex items-center gap-1 h-5 px-1.5 rounded-md
+                  text-[11px] leading-[1] text-blue-600 hover:underline hover:bg-blue-50/60
+                  focus:outline-none focus:ring-1 focus:ring-blue-300/70
                   ${className}`}
     >
-      {/* コピー前アイコン */}
-      <svg viewBox="0 0 24 24" className={`w-3.5 h-3.5 shrink-0 ${copied ? 'hidden' : ''}`} aria-hidden="true">
-        <path fill="currentColor" d="M16 1H6a2 2 0 0 0-2 2v12h2V3h10V1zm3 4H10a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h9a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2zm0 16H10V7h9v14z"/>
-      </svg>
-      {/* 成功アイコン */}
-      <svg viewBox="0 0 24 24" className={`w-3.5 h-3.5 shrink-0 text-blue-600 ${copied ? '' : 'hidden'}`} aria-hidden="true">
-        <path fill="currentColor" d="M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4z"/>
-      </svg>
-
+      <Icon ok={copied} />
       <span className="select-none">{copied ? 'コピーしました' : 'リンクをコピー'}</span>
     </button>
   );
 }
+


### PR DESCRIPTION
## Summary
- add compact CopyLink component with text and icon variants
- adjust post header to use new CopyLink and semantic time tags

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: `next: not found`)


------
https://chatgpt.com/codex/tasks/task_b_68a33c43e1ac832397b65c2c8a11b257