### PR TITLE
feat: simplify copy link component

### DIFF
--- a/components/CopyLink.tsx
+++ b/components/CopyLink.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useState } from 'react';
 
-type Variant = 'link' | 'icon'; // link=テキストリンク風, icon=アイコンだけ
+type Variant = 'link' | 'icon';
 
 export default function CopyLink({
   url,
@@ -18,8 +18,7 @@ export default function CopyLink({
     const text = String(url || '');
     try {
       await navigator.clipboard.writeText(text);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
+      ok();
     } catch {
       try {
         const ta = document.createElement('textarea');
@@ -31,39 +30,42 @@ export default function CopyLink({
         ta.select();
         document.execCommand('copy');
         document.body.removeChild(ta);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
+        ok();
       } catch {
         window.prompt('コピーできませんでした。下のテキストをコピーしてください。', text);
       }
     }
   }
 
-  // 共通アイコン
-  const Icon = ({ ok }: { ok: boolean }) => (
+  function ok() {
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1200);
+  }
+
+  // アイコン（SVGにwidth/height属性を直書き = どんなCSSでも巨大化しない）
+  const Icon = ({ ok = false }) =>
     ok ? (
-      <svg viewBox="0 0 24 24" className="w-3.5 h-3.5 text-blue-600" aria-hidden="true">
+      <svg width="14" height="14" viewBox="0 0 24 24" className="shrink-0" aria-hidden="true">
         <path fill="currentColor" d="M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4z" />
       </svg>
     ) : (
-      <svg viewBox="0 0 24 24" className="w-3.5 h-3.5" aria-hidden="true">
-        <path
-          fill="currentColor"
-          d="M16 1H6a2 2 0 0 0-2 2v12h2V3h10V1zm3 4H10a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h9a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2zm0 16H10V7h9v14z"
-        />
+      <svg width="14" height="14" viewBox="0 0 24 24" className="shrink-0" aria-hidden="true">
+        <path fill="currentColor" d="M16 1H6a2 2 0 0 0-2 2v12h2V3h10V1zm3 4H10a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h9a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2zm0 16H10V7h9v14z" />
       </svg>
-    )
-  );
+    );
 
   if (variant === 'icon') {
-    // アイコンだけ（さらに小さく）
+    // アイコンだけ（極小・余白ゼロ）
     return (
       <button
         type="button"
         onClick={doCopy}
+        data-copylink
         aria-label={copied ? 'コピーしました' : 'リンクをコピー'}
-        className={`not-prose inline-flex h-5 w-5 items-center justify-center rounded-md
-                    text-gray-500 hover:text-blue-600 focus:outline-none focus:ring-1 focus:ring-blue-300/70
+        className={`not-prose inline-flex h-4 w-4 items-center justify-center
+                    appearance-none bg-transparent p-0 rounded
+                    text-gray-500 hover:text-blue-600
+                    focus:outline-none focus:ring-1 focus:ring-blue-300/70
                     ${className}`}
       >
         <Icon ok={copied} />
@@ -71,14 +73,16 @@ export default function CopyLink({
     );
   }
 
-  // デフォルト：テキストリンク風（極小）
+  // テキストリンク風（極小）
   return (
     <button
       type="button"
       onClick={doCopy}
+      data-copylink
       aria-live="polite"
-      className={`not-prose inline-flex items-center gap-1 h-5 px-1.5 rounded-md
-                  text-[11px] leading-[1] text-blue-600 hover:underline hover:bg-blue-50/60
+      className={`not-prose inline-flex items-center gap-1
+                  appearance-none bg-transparent h-5 px-1.5 rounded
+                  text-xs leading-none text-blue-600 hover:underline hover:bg-blue-50/60
                   focus:outline-none focus:ring-1 focus:ring-blue-300/70
                   ${className}`}
     >


### PR DESCRIPTION
## Summary
- simplify CopyLink button with icon or link variants
- ensure icons stay tiny with explicit dimensions

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: sh: 1: next: not found)
- `npm ci` (fails: package.json and package-lock.json are not in sync)

------
https://chatgpt.com/codex/tasks/task_b_68a343aef79c83239341dd0cc59d6b56