### PR TITLE
Fix mobile hero image layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -491,3 +491,13 @@ article h2, article h3 { scroll-margin-top: 96px; }
   border-radius: 0.75rem; /* 12px 相当 */
 }
 
+/* スマホで横長ヒーロー画像の高さを抑える */
+@media (max-width: 640px) {
+  .post-hero img {
+    max-height: 220px;
+    width: 100%;
+    object-fit: cover;
+    object-position: center 20%;
+  }
+}
+

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -110,7 +110,7 @@ export default async function PostPage({ params }: { params: { slug: string } })
               )}
               <CopyLink url={`${BASE}${canonical}`} className="ml-1" />
             </div>
-            <div className="mt-4">
+            <div className="mt-4 post-hero rounded-xl border border-gray-100 overflow-hidden">
               <Image
                 src={hero}
                 alt={post.title}
@@ -118,7 +118,7 @@ export default async function PostPage({ params }: { params: { slug: string } })
                 height={630}               // 16:9相当
                 priority
                 sizes="(max-width:768px) 100vw, 720px"
-                className="w-full h-auto rounded-xl border border-gray-100 object-cover"
+                className="w-full h-auto"
               />
             </div>
           </header>


### PR DESCRIPTION
## Summary
- restrict blog post hero image height on small screens
- add mobile CSS to crop tall hero images

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a47416346483239a817c6d92f5d67a