### PR TITLE
Refactor post cards and grids

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,5 @@
 import Image from "next/image";
 import PostCard from "@/components/PostCard";
-import Reveal from "@/components/Reveal";
 import { getAllPostsMeta } from "@/lib/posts";
 
 const MASCOT = "/otoron.webp";
@@ -23,7 +22,7 @@ export default async function Page() {
   const rest = posts.filter((p: any) => !p.featured);
 
   return (
-    <main className="wrap">
+    <main className="mx-auto max-w-5xl px-4 py-12">
       <div className="hero">
         <div className="heroText">
           <h1 className="pageTitle">オトロン公式ブログ</h1>
@@ -48,33 +47,31 @@ export default async function Page() {
           <h2 className="text-base font-semibold text-gray-700">注目記事</h2>
           <div className="mt-3 grid grid-cols-1 gap-6 sm:grid-cols-3">
             {featured.map((p: any) => (
-              <Reveal key={p.slug}>
-                <PostCard
-                  slug={p.slug}
-                  title={p.title}
-                  description={p.description}
-                  date={p.date}
-                  thumb={p.thumb || p.ogImage}
-                />
-              </Reveal>
+              <PostCard
+                key={p.slug}
+                slug={p.slug}
+                title={p.title}
+                description={p.description}
+                date={p.date}
+                thumb={p.thumb || p.ogImage}
+              />
             ))}
           </div>
         </section>
       )}
 
-      <section className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+      <div className="mt-8 grid grid-cols-1 gap-6 sm:grid-cols-2">
         {rest.map((p: any) => (
-          <Reveal key={p.slug}>
-            <PostCard
-              slug={p.slug}
-              title={p.title}
-              description={p.description}
-              date={p.date}
-              thumb={p.thumb || p.ogImage}
-            />
-          </Reveal>
+          <PostCard
+            key={p.slug}
+            slug={p.slug}
+            title={p.title}
+            description={p.description}
+            date={p.date}
+            thumb={p.thumb || p.ogImage}
+          />
         ))}
-      </section>
+      </div>
     </main>
   );
 }

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -10,7 +10,6 @@ import { tagSlug } from "@/lib/tags";
 import PostCard from "@/components/PostCard";
 import TableOfContents from "@/components/TableOfContents";
 import CopyLink from "@/components/CopyLink";
-import Reveal from "@/components/Reveal";
 
 const BASE = process.env.NEXT_PUBLIC_SITE_URL || "https://playotoron.com";
 const FALLBACK_THUMB = "/otolon_face.webp";
@@ -166,15 +165,14 @@ export default async function PostPage({ params }: { params: { slug: string } })
               </h2>
               <div className="mt-4 grid grid-cols-1 gap-6 sm:grid-cols-2">
                 {related.map((p: any) => (
-                  <Reveal key={p.slug}>
-                    <PostCard
-                      slug={p.slug}
-                      title={p.title}
-                      description={p.description}
-                      date={p.date}
-                      thumb={p.thumb}
-                    />
-                  </Reveal>
+                  <PostCard
+                    key={p.slug}
+                    slug={p.slug}
+                    title={p.title}
+                    description={p.description}
+                    date={p.date}
+                    thumb={p.thumb}
+                  />
                 ))}
               </div>
             </section>

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -1,28 +1,42 @@
 import Image from 'next/image';
 
-export default function PostCard({ slug, title, description, date, thumb }: any) {
+type CardProps = {
+  slug: string;
+  title: string;
+  description: string;
+  date: string;
+  thumb?: string;
+};
+
+export default function PostCard({ slug, title, description, date, thumb }: CardProps) {
   const href = `/blog/posts/${slug}`;
-  const img = thumb || '/otolon_face.webp';
+  const img  = thumb || '/otolon_face.webp';
 
   return (
-    <a href={href} className="block rounded-xl border border-gray-100 bg-white shadow-sm transition hover:shadow-md">
-      <div className="relative aspect-[16/9] overflow-hidden rounded-t-xl bg-gray-50">
+    <a
+      href={href}
+      className="group block rounded-2xl border border-gray-100 bg-white shadow-sm transition hover:shadow-md"
+    >
+      {/* ←ここが超重要：relative + aspect + overflow-hidden */}
+      <div className="relative aspect-[16/9] w-full overflow-hidden rounded-t-2xl bg-gray-50">
         <Image
           src={img}
           alt={title}
           fill
-          sizes="(max-width:768px) 100vw, 400px"
-          className="object-cover transition duration-300 group-hover:scale-[1.02]"
+          sizes="(max-width: 640px) 100vw, 520px"
+          className="object-cover"
           priority={false}
         />
       </div>
+
       <div className="p-4">
         <time className="block text-xs text-gray-400">
           {new Date(date).toLocaleDateString('ja-JP')}
         </time>
-        <h3 className="mt-1 font-semibold text-gray-900">{title}</h3>
-        <p className="mt-1 text-sm text-gray-600">{description}</p>
+        <h3 className="mt-1 font-semibold leading-snug line-clamp-2">{title}</h3>
+        <p className="mt-1 text-sm text-gray-600 line-clamp-3">{description}</p>
       </div>
     </a>
   );
 }
+


### PR DESCRIPTION
## Summary
- replace PostCard with minimal version using responsive 16:9 thumbnail
- render related posts outside `.prose` and simplify grid usage
- streamline home page grids and remove animation wrappers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a488551e2c83239992c68000b56ea7