### PR TITLE
Fix hero image containers and add Next/Image guard

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,6 +4,16 @@ html,body{margin:0;padding:0;background:var(--bg);color:var(--ink);font-family:s
 /* 画像が親幅を超えて暴れないための保険 */
 img, picture, video, canvas, svg { max-width: 100%; height: auto; }
 
+/* next/image が吐く <img> には一切干渉しない（念のため） */
+span[data-nimg] > img {
+  all: unset;
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
 /* prose(typography) 使用時も高さが固定化されないように */
 .prose img { height: auto; }
 a,.brand{color:var(--brand);text-decoration:none}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,8 +18,12 @@ export default async function Page() {
     .filter((p: any) => !p.draft)
     .sort((a: any, b: any) => (a.date < b.date ? 1 : -1));
 
-  const featured = posts.filter((p: any) => p.featured).slice(0, 3);
-  const rest = posts.filter((p: any) => !p.featured);
+  const [latest, ...others] = posts;
+  const hero = latest.thumb || latest.ogImage || "/otolon_face.webp";
+  const title = latest.title;
+
+  const featured = others.filter((p: any) => p.featured).slice(0, 3);
+  const rest = others.filter((p: any) => !p.featured);
 
   return (
     <main className="mx-auto max-w-5xl px-4 py-12">
@@ -29,17 +33,31 @@ export default async function Page() {
           <p className="lede">
             絶対音感トレーニングのノウハウ、幼児の耳育て、アプリ活用ガイドなどをお届けします。
           </p>
-        </div>
-        <div className="mascot">
-          <Image
-            src={MASCOT}
-            alt="オトロン"
-            fill
-            sizes="80px"
-            className="mascotImg"
-            priority={false}
-          />
-        </div>
+      </div>
+      <div className="mascot">
+        <Image
+          src={MASCOT}
+          alt="オトロン"
+          fill
+          sizes="80px"
+          className="mascotImg"
+          priority={false}
+        />
+      </div>
+    </div>
+
+      <div
+        className="relative mx-auto mt-4 w-full max-w-[720px] overflow-hidden rounded-xl border border-gray-100"
+        style={{ aspectRatio: "16 / 9" }}
+      >
+        <Image
+          src={hero}
+          alt={title}
+          fill
+          priority
+          sizes="(max-width:768px) 100vw, 720px"
+          className="object-cover"
+        />
       </div>
 
       {featured.length > 0 && (

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -96,16 +96,16 @@ export default async function PostPage({ params }: { params: { slug: string } })
 
             {/* ←親に 16/9 の“枠”＋最大幅を与える。fill は object-cover で収める */}
             <div
-              className="relative mx-auto mt-4 w-full max-w-[720px] overflow-hidden rounded-xl border border-gray-100"
+              className="relative mt-4 w-full max-w-[720px] overflow-hidden rounded-xl border border-gray-100"
               style={{ aspectRatio: "16 / 9" }}
             >
               <Image
                 src={hero}
                 alt={post.title}
                 fill
-                className="object-cover"
-                sizes="(min-width:1024px) 720px, 100vw"
                 priority
+                sizes="(max-width:768px) 100vw, 720px"
+                className="object-cover"
               />
             </div>
           </header>

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -10,19 +10,18 @@ type CardProps = {
 
 export default function PostCard({ slug, title, description, date, thumb }: CardProps) {
   const href = `/blog/posts/${slug}`;
-  const src  = thumb || "/otolon_face.webp";
+  const img = thumb || "/otolon_face.webp";
 
   return (
-    <a href={href} className="group block rounded-2xl border bg-white shadow-sm transition hover:shadow-md">
+    <a href={href} className="group block rounded-2xl border border-gray-100 bg-white shadow-sm transition hover:shadow-md">
       {/* ←画像は必ず「枠」で囲う（16/9）。ここが最重要 */}
       <div className="relative w-full overflow-hidden rounded-t-2xl" style={{ aspectRatio: "16 / 9" }}>
         <Image
-          src={src}
+          src={img}
           alt={title}
           fill
+          sizes="(max-width:640px) 100vw, 360px"
           className="object-cover"
-          // ここも重要：一覧カードで実際に使う幅だけを宣言
-          sizes="(min-width:1024px) 560px, (min-width:640px) 50vw, 100vw"
           priority={false}
         />
       </div>


### PR DESCRIPTION
## Summary
- Ensure post and top page hero images have a relative, fixed-aspect container
- Standardize PostCard thumbnail wrapper and sizes
- Add CSS guard so global img rules don't override Next/Image output

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a56214b2388323b7a58938e47cb691