### PR TITLE
Define PostMeta type and use it

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import PostCard from "@/components/PostCard";
-import { getAllPostsMeta } from "@/lib/posts";
+import { getAllPostsMeta, type PostMeta } from "@/lib/posts";
 
 const MASCOT = "/otoron.webp";
 
@@ -14,16 +14,16 @@ export const metadata = {
 };
 
 export default async function Page() {
-  const posts = getAllPostsMeta()
-    .filter((p: any) => !p.draft)
-    .sort((a: any, b: any) => (a.date < b.date ? 1 : -1));
+  const posts: PostMeta[] = (await getAllPostsMeta())
+    .filter((p) => !p.draft)
+    .sort((a, b) => (a.date < b.date ? 1 : -1));
 
   const [latest, ...others] = posts;
-  const hero = latest.thumb || latest.ogImage || "/otolon_face.webp";
+  const hero = latest.thumb ?? latest.ogImage ?? "/otolon_face.webp";
   const title = latest.title;
 
-  const featured = others.filter((p: any) => p.featured).slice(0, 3);
-  const rest = others.filter((p: any) => !p.featured);
+  const featured = others.filter((p) => p.featured).slice(0, 3);
+  const rest = others.filter((p) => !p.featured);
 
   return (
     <main className="mx-auto max-w-5xl px-4 py-12">
@@ -64,16 +64,30 @@ export default async function Page() {
         <section className="mb-8">
           <h2 className="text-base font-semibold text-gray-700">注目記事</h2>
           <div className="mt-3 grid grid-cols-1 gap-6 sm:grid-cols-3">
-            {featured.map((p: any) => (
-              <PostCard key={p.slug} {...p} />
+            {featured.map((p) => (
+              <PostCard
+                key={p.slug}
+                slug={p.slug}
+                title={p.title}
+                description={p.description}
+                date={p.date}
+                thumb={p.thumb}
+              />
             ))}
           </div>
         </section>
       )}
 
       <div className="mt-8 grid grid-cols-1 gap-6 sm:grid-cols-2">
-        {rest.map((p: any) => (
-          <PostCard key={p.slug} {...p} />
+        {rest.map((p) => (
+          <PostCard
+            key={p.slug}
+            slug={p.slug}
+            title={p.title}
+            description={p.description}
+            date={p.date}
+            thumb={p.thumb}
+          />
         ))}
       </div>
     </main>

--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { headers } from 'next/headers';
-import { getAllPostsMeta } from '@/lib/posts';
+import { getAllPostsMeta, type PostMeta } from '@/lib/posts';
 
 export const runtime = 'nodejs';
 
@@ -14,9 +14,9 @@ function siteBase() {
 
 export async function GET() {
   const SITE = siteBase();
-  const posts = (await getAllPostsMeta() as any[])
-    .filter((p: any) => !p.draft)
-    .sort((a: any, b: any) => (a.date < b.date ? 1 : -1))
+  const posts: PostMeta[] = (await getAllPostsMeta())
+    .filter((p) => !p.draft)
+    .sort((a, b) => (a.date < b.date ? 1 : -1))
     .slice(0, 20);
 
   const items = posts.map(p => {

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { headers } from 'next/headers';
-import { getAllPostsMeta } from '@/lib/posts';
+import { getAllPostsMeta, type PostMeta } from '@/lib/posts';
 import { getAllTags } from '@/lib/tags';
 
 export const runtime = 'nodejs';
@@ -15,13 +15,13 @@ function siteBase() {
 
 export async function GET() {
   const SITE = siteBase();
-  const posts = (await getAllPostsMeta() as any[]).filter((p: any) => !p.draft);
+  const posts: PostMeta[] = (await getAllPostsMeta()).filter((p) => !p.draft);
   const tags = await getAllTags();
   const nowISO = new Date().toISOString();
 
   const urls = [
     { loc: `${SITE}/blog`, lastmod: nowISO },
-    ...posts.map((p: any) => ({
+    ...posts.map((p) => ({
       loc: `${SITE}/blog/posts/${p.slug}`,
       lastmod: new Date(p.date).toISOString(),
     })),

--- a/lib/tags.ts
+++ b/lib/tags.ts
@@ -1,13 +1,4 @@
-import { getAllPostsMeta } from "@/lib/posts";
-
-type PostMeta = {
-  slug: string;
-  title?: string;
-  description?: string;
-  date?: string;
-  draft?: boolean;
-  tags?: string[];
-};
+import { getAllPostsMeta, type PostMeta } from "@/lib/posts";
 
 export function tagSlug(s: string) {
   return s
@@ -18,8 +9,7 @@ export function tagSlug(s: string) {
 }
 
 export async function getAllTags() {
-  const posts = (await getAllPostsMeta() as unknown as PostMeta[])
-    .filter(p => !p.draft);
+  const posts: PostMeta[] = (await getAllPostsMeta()).filter(p => !p.draft);
 
   const acc = new Map<string, { slug: string; name: string; count: number }>();
   for (const p of posts) {
@@ -37,10 +27,11 @@ export async function getAllTags() {
 
 export async function getPostsByTag(tagOrSlug: string) {
   const slug = tagSlug(tagOrSlug);
-  const posts = (await getAllPostsMeta() as unknown as PostMeta[])
-    .filter(p =>
-      !p.draft &&
-      (Array.isArray(p.tags) ? p.tags : []).some(t => tagSlug(t) === slug)
+  const posts: PostMeta[] = (await getAllPostsMeta())
+    .filter(
+      (p) =>
+        !p.draft &&
+        (Array.isArray(p.tags) ? p.tags : []).some((t) => tagSlug(t) === slug)
     )
     .sort((a, b) => (a.date ?? "") < (b.date ?? "") ? 1 : -1);
   return posts;

--- a/types/posts.d.ts
+++ b/types/posts.d.ts
@@ -1,22 +1,40 @@
-export type BlogPost = {
-  slug: string;
-  date: string;
-  content: string;
-  title?: string;
-  description?: string;
-  ogImage?: string;
-  updated?: string;
-  draft?: boolean;
-  featured?: boolean;
-  readingMinutes?: number;
-};
-
 declare module "@/lib/posts" {
-  import type { BlogPost } from "../types/posts";
+  export type PostMeta = {
+    slug: string;
+    title: string;
+    description: string;
+    date: string;
+    updated?: string;
+    ogImage?: string;
+    thumb?: string;
+    featured?: boolean;
+    tags?: string[];
+    draft?: boolean;
+    readingMinutes?: number;
+  };
+
+  export type BlogPost = PostMeta & {
+    content: string;
+  };
+
   export function getAllPosts(): BlogPost[];
+  export function getAllPostsMeta(): PostMeta[];
   export function getPost(slug: string): BlogPost | null;
   export function getPrevNext(slug: string): {
     prev: BlogPost | null;
     next: BlogPost | null;
   };
+  export function getPostBySlug(slug: string): Promise<
+    (BlogPost & {
+      html: string;
+      headings: { depth: number; text: string; id: string }[];
+    }) | null
+  >;
+  export function getAdjacentPosts(slug: string): Promise<{
+    prev: BlogPost | null;
+    next: BlogPost | null;
+  }>;
+  export function getRelatedPosts(slug: string, limit?: number): Promise<PostMeta[]>;
+  export function getAllSlugs(): string[];
 }
+


### PR DESCRIPTION
## Summary
- Add PostMeta type to lib/posts declarations and expose BlogPost type
- Update page and route handlers to consume typed post metadata
- Clean up tags utilities to rely on PostMeta

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm install --no-progress` *(fails: 403 Forbidden - GET https://registry.npmjs.org/eslint)*

------
https://chatgpt.com/codex/tasks/task_b_68a5d276b128832388e5f901f1183067