### PR TITLE
Refactor hero images with aspect ratio wrappers

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -448,8 +448,6 @@ h1.page-title{ font-size:clamp(28px,5vw,40px); line-height:1.2; margin:24px 0 8p
 
 /* ========== Post */
 .postHeader { margin-bottom: 18px; }
-.heroMedia { position: relative; width: 100%; height: clamp(180px, 36vw, 360px); border-radius: 14px; overflow: hidden; background: #f6f7fb; }
-.heroMediaImg { object-fit: cover; }
 .postTitle { margin: 14px 0 6px; font-size: clamp(22px, 4vw, 34px); line-height: 1.25; }
 .meta { color: var(--muted); font-size: 14px; }
 
@@ -507,16 +505,6 @@ article h2, article h3 { scroll-margin-top: 96px; }
   border-radius: 0.75rem; /* 12px 相当 */
 }
 
-/* スマホで横長ヒーロー画像の高さを抑える */
-@media (max-width: 640px) {
-  .post-hero img {
-    max-height: 220px;
-    width: 100%;
-    object-fit: cover;
-    object-position: center 20%;
-  }
-}
-
 /* ---- reveal once ---- */
 .reveal {
   opacity: 0;
@@ -529,4 +517,11 @@ article h2, article h3 { scroll-margin-top: 96px; }
 @keyframes fadeUp {
   to { opacity: 1; transform: none; }
 }
+
+/* Next/Image の fill が親をはみ出さないための“安全策” */
+.nimg, .nimg span, .nimg img { display:block }
+img, picture, video, canvas { max-width: 100%; height: auto }
+
+/* もし過去の修正で「高さを決め打ち」していたクラスがあれば無効化 */
+/* 例: .post-hero { height: auto !important; } */
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -47,16 +47,16 @@ export default async function Page() {
     </div>
 
       <div
-        className="relative mx-auto mt-4 w-full max-w-[720px] overflow-hidden rounded-xl border border-gray-100"
+        className="relative mx-auto mt-4 w-full max-w-4xl overflow-hidden rounded-2xl border border-gray-100 bg-gray-50"
         style={{ aspectRatio: "16 / 9" }}
       >
         <Image
           src={hero}
           alt={title}
           fill
-          priority
-          sizes="(max-width:768px) 100vw, 720px"
+          sizes="(max-width: 768px) 100vw, 960px"
           className="object-cover"
+          priority
         />
       </div>
 

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -96,7 +96,7 @@ export default async function PostPage({ params }: { params: { slug: string } })
 
             {/* ←親に 16/9 の“枠”＋最大幅を与える。fill は object-cover で収める */}
             <div
-              className="relative mt-4 w-full max-w-[720px] overflow-hidden rounded-xl border border-gray-100"
+              className="relative mt-4 w-full max-w-[720px] overflow-hidden rounded-xl border border-gray-100 bg-gray-50"
               style={{ aspectRatio: "16 / 9" }}
             >
               <Image
@@ -104,7 +104,7 @@ export default async function PostPage({ params }: { params: { slug: string } })
                 alt={post.title}
                 fill
                 priority
-                sizes="(max-width:768px) 100vw, 720px"
+                sizes="(max-width: 768px) 100vw, 720px"
                 className="object-cover"
               />
             </div>

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -14,22 +14,28 @@ export default function PostCard({ slug, title, description, date, thumb }: Card
 
   return (
     <a href={href} className="group block rounded-2xl border border-gray-100 bg-white shadow-sm transition hover:shadow-md">
-      {/* ←画像は必ず「枠」で囲う（16/9）。ここが最重要 */}
-      <div className="relative w-full overflow-hidden rounded-t-2xl" style={{ aspectRatio: "16 / 9" }}>
+      {/* サムネ */}
+      <div
+        className="relative w-full overflow-hidden rounded-t-2xl bg-gray-50"
+        style={{ aspectRatio: "16 / 9" }}
+      >
         <Image
           src={img}
           alt={title}
           fill
-          sizes="(max-width:640px) 100vw, 360px"
+          sizes="(max-width: 640px) 100vw, 384px"
           className="object-cover"
           priority={false}
         />
       </div>
 
+      {/* テキスト */}
       <div className="p-4">
-        <time className="block text-xs text-gray-400">{new Date(date).toLocaleDateString("ja-JP")}</time>
-        <h3 className="mt-1 line-clamp-2 font-semibold leading-snug">{title}</h3>
-        <p className="mt-1 text-sm text-gray-600 line-clamp-2">{description}</p>
+        <div className="text-sm text-gray-400">
+          {new Date(date).toLocaleDateString("ja-JP")}
+        </div>
+        <h3 className="mt-1 line-clamp-2 text-base font-semibold leading-snug">{title}</h3>
+        <p className="mt-1 line-clamp-2 text-sm text-gray-600">{description}</p>
       </div>
     </a>
   );


### PR DESCRIPTION
## Summary
- use fixed-aspect containers for post and index hero images
- update post cards to wrap thumbnails in 16:9 gray boxes
- add global safety styles for next/image

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a5de98cf4483239e1a227986cc13cf