### PR TITLE
fix: avoid setting height on Next.js image wrapper

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,14 +4,15 @@ html,body{margin:0;padding:0;background:var(--bg);color:var(--ink);font-family:s
 /* 画像が親幅を超えて暴れないための保険 */
 img, picture, video, canvas, svg { max-width: 100%; height: auto; }
 
-/* Next/Image の fill を安全に動かすための最小限の調整 */
-span[data-nimg] {
-  position: relative;      /* ← これが無いと img の absolute がビューポート基準になって崩れます */
+/* Next/Image wrapper: 高さは “決めない”（各コンポーネント側で決める） */
+span[data-nimg]{
+  position: relative;
   display: block;
   width: 100%;
-  height: 100%;
+  height: auto;        /* ← 高さはここで与えない */
   overflow: hidden;
 }
+/* 中の <img> は fill のままでOK */
 span[data-nimg] > img {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
## Summary
- avoid forcing 100% height on `span[data-nimg]`
- document that Next/Image wrappers should not define height globally

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a6fe3bfc2c83239da375a064fde92b