### PR TITLE
refactor: remove global image fill hacks

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,22 +4,6 @@ html,body{margin:0;padding:0;background:var(--bg);color:var(--ink);font-family:s
 /* 画像が親幅を超えて暴れないための保険 */
 img, picture, video, canvas, svg { max-width: 100%; height: auto; }
 
-/* Next/Image wrapper: 高さは “決めない”（各コンポーネント側で決める） */
-span[data-nimg]{
-  position: relative;
-  display: block;
-  width: 100%;
-  height: auto;        /* ← 高さはここで与えない */
-  overflow: hidden;
-}
-/* 中の <img> は fill のままでOK */
-span[data-nimg] > img {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
 
 /* prose(typography) 使用時も高さが固定化されないように */
 .prose img { height: auto; }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -38,24 +38,26 @@ export default async function Page() {
         <Image
           src={MASCOT}
           alt="オトロン"
-          fill
+          width={110}
+          height={110}
           sizes="80px"
-          className="mascotImg"
+          className="mascotImg h-full w-full"
           priority={false}
         />
       </div>
     </div>
 
       <div
-        className="relative mx-auto mt-4 w-full max-w-4xl overflow-hidden rounded-2xl border border-gray-100 bg-gray-50"
+        className="mx-auto mt-4 w-full max-w-4xl overflow-hidden rounded-2xl border border-gray-100 bg-gray-50"
         style={{ aspectRatio: "16 / 9" }}
       >
         <Image
           src={hero}
           alt={title}
-          fill
+          width={1200}
+          height={675}
           sizes="(max-width: 768px) 100vw, 960px"
-          className="object-cover"
+          className="h-full w-full object-cover"
           priority
         />
       </div>

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -94,18 +94,19 @@ export default async function PostPage({ params }: { params: { slug: string } })
               {new Date(post.date).toLocaleDateString("ja-JP")}
             </time>
 
-            {/* ←親に 16/9 の“枠”＋最大幅を与える。fill は object-cover で収める */}
+            {/* ←親に 16/9 の“枠”＋最大幅を与えて画像を収める */}
             <div
-              className="relative mt-4 w-full max-w-[720px] overflow-hidden rounded-xl border border-gray-100 bg-gray-50"
+              className="mt-4 w-full max-w-[720px] overflow-hidden rounded-xl border border-gray-100 bg-gray-50"
               style={{ aspectRatio: "16 / 9" }}
             >
               <Image
                 src={hero}
                 alt={post.title}
-                fill
+                width={1200}
+                height={675}
                 priority
                 sizes="(max-width: 768px) 100vw, 720px"
-                className="object-cover"
+                className="h-full w-full object-cover"
               />
             </div>
           </header>

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -16,16 +16,16 @@ export default function PostCard({ slug, title, description, date, thumb }: Card
     <a href={href} className="group block rounded-2xl border border-gray-100 bg-white shadow-sm transition hover:shadow-md">
       {/* サムネ */}
       <div
-        className="relative w-full overflow-hidden rounded-t-2xl bg-gray-50"
+        className="overflow-hidden rounded-t-2xl bg-gray-50"
         style={{ aspectRatio: "16 / 9" }}
       >
         <Image
           src={img}
           alt={title}
-          fill
+          width={640}
+          height={360}
+          className="h-full w-full object-cover"
           sizes="(max-width: 640px) 100vw, 384px"
-          className="object-cover"
-          priority={false}
         />
       </div>
 


### PR DESCRIPTION
## Summary
- remove Next/Image global wrapper CSS hack
- update PostCard, post hero, and home page images to use explicit dimensions instead of `fill`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: sh: 1: next: not found)

------
https://chatgpt.com/codex/tasks/task_b_68a71bbf3cc08323bb9dc7f079131608