### PR TITLE
Refactor image layout for heroes and cards

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -509,8 +509,8 @@ article h2, article h3 { scroll-margin-top: 96px; }
   to { opacity: 1; transform: none; }
 }
 
-/* Next/Image の fill が親をはみ出さないための“安全策” */
-.nimg, .nimg span, .nimg img { display:block }
+/* Next/Image の wrapper をブロック要素化するだけ（高さは決めない） */
+span[data-nimg] { display: block; }
 img, picture, video, canvas { max-width: 100%; height: auto }
 
 /* もし過去の修正で「高さを決め打ち」していたクラスがあれば無効化 */

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -47,18 +47,14 @@ export default async function Page() {
       </div>
     </div>
 
-      <div
-        className="mx-auto mt-4 w-full max-w-4xl overflow-hidden rounded-2xl border border-gray-100 bg-gray-50"
-        style={{ aspectRatio: "16 / 9" }}
-      >
+      <div className="relative mt-4 mx-auto w-full max-w-4xl aspect-[16/9] post-hero overflow-hidden rounded-xl border bg-gray-100">
         <Image
           src={hero}
           alt={title}
-          width={1200}
-          height={675}
-          sizes="(max-width: 768px) 100vw, 960px"
-          className="h-full w-full object-cover"
+          fill
           priority
+          sizes="(max-width:768px) 100vw, 720px"
+          className={hero.includes("otolon_face") ? "object-contain" : "object-cover"}
         />
       </div>
 

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -95,18 +95,14 @@ export default async function PostPage({ params }: { params: { slug: string } })
             </time>
 
             {/* ←親に 16/9 の“枠”＋最大幅を与えて画像を収める */}
-            <div
-              className="mt-4 w-full max-w-[720px] overflow-hidden rounded-xl border border-gray-100 bg-gray-50"
-              style={{ aspectRatio: "16 / 9" }}
-            >
+            <div className="relative mt-4 aspect-[16/9] w-full overflow-hidden rounded-xl border border-gray-100">
               <Image
                 src={hero}
                 alt={post.title}
-                width={1200}
-                height={675}
+                fill
                 priority
-                sizes="(max-width: 768px) 100vw, 720px"
-                className="h-full w-full object-cover"
+                sizes="(max-width:768px) 100vw, 720px"
+                className={hero.includes("otolon_face") ? "object-contain" : "object-cover"}
               />
             </div>
           </header>

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import clsx from "clsx";
 
 type CardProps = {
   slug: string;
@@ -9,23 +10,23 @@ type CardProps = {
 };
 
 export default function PostCard({ slug, title, description, date, thumb }: CardProps) {
-  const href = `/blog/posts/${slug}`;
   const img = thumb || "/otolon_face.webp";
+  const isSquareFallback = img.includes("otolon_face");
 
   return (
-    <a href={href} className="group block rounded-2xl border border-gray-100 bg-white shadow-sm transition hover:shadow-md">
-      {/* サムネ */}
-      <div
-        className="overflow-hidden rounded-t-2xl bg-gray-50"
-        style={{ aspectRatio: "16 / 9" }}
-      >
+    <a
+      href={`/blog/posts/${slug}`}
+      className="group block rounded-2xl border bg-white shadow-md transition hover:shadow-lg"
+    >
+      {/* 画像ラッパー：ここで 16:9 を決める */}
+      <div className="relative aspect-[16/9] w-full overflow-hidden rounded-t-2xl bg-gray-50">
         <Image
           src={img}
           alt={title}
-          width={640}
-          height={360}
-          className="h-full w-full object-cover"
-          sizes="(max-width: 640px) 100vw, 384px"
+          fill
+          sizes="(max-width:640px) 100vw, 384px"
+          className={clsx(isSquareFallback ? "object-contain" : "object-cover")}
+          priority={false}
         />
       </div>
 


### PR DESCRIPTION
## Summary
- render blog card images and hero images with `next/image` in `fill` mode and aspect-ratio wrappers
- use `object-contain` only for the square fallback image
- add minimal CSS guard for Next.js image wrapper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found; `npm ci` forbidden by registry 403)*

------
https://chatgpt.com/codex/tasks/task_b_68a75310f3088323a406d35bdc9f1b35