### PR TITLE
refactor: replace clsx with local cn helper

### DIFF
--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -1,5 +1,5 @@
 import Image from "next/image";
-import clsx from "clsx";
+import { cn } from "../lib/cn";
 
 type CardProps = {
   slug: string;
@@ -25,7 +25,7 @@ export default function PostCard({ slug, title, description, date, thumb }: Card
           alt={title}
           fill
           sizes="(max-width:640px) 100vw, 384px"
-          className={clsx(isSquareFallback ? "object-contain" : "object-cover")}
+          className={cn(isSquareFallback ? "object-contain" : "object-cover")}
           priority={false}
         />
       </div>

--- a/lib/cn.ts
+++ b/lib/cn.ts
@@ -1,0 +1,28 @@
+type ClassValue =
+  | string
+  | number
+  | null
+  | undefined
+  | false
+  | ClassValue[]
+  | Record<string, any>;
+
+export function cn(...inputs: ClassValue[]): string {
+  const out: string[] = [];
+
+  const push = (x: ClassValue) => {
+    if (!x) return;
+    if (typeof x === "string" || typeof x === "number") {
+      out.push(String(x));
+    } else if (Array.isArray(x)) {
+      for (const v of x) push(v);
+    } else if (typeof x === "object") {
+      for (const k in x) {
+        if (Object.prototype.hasOwnProperty.call(x, k) && x[k]) out.push(k);
+      }
+    }
+  };
+
+  for (const i of inputs) push(i);
+  return out.join(" ");
+}


### PR DESCRIPTION
## Summary
- add minimal `cn` classnames helper in `lib`
- refactor `PostCard` to use new `cn` instead of `clsx`

## Testing
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a9772060c08323b8f6018259d85749