### PR TITLE
refactor: use static dimensions for images

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -509,10 +509,6 @@ article h2, article h3 { scroll-margin-top: 96px; }
   to { opacity: 1; transform: none; }
 }
 
-/* Next/Image の wrapper をブロック要素化するだけ（高さは決めない） */
-span[data-nimg] { display: block; }
-img, picture, video, canvas { max-width: 100%; height: auto }
-
 /* もし過去の修正で「高さを決め打ち」していたクラスがあれば無効化 */
 /* 例: .post-hero { height: auto !important; } */
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -47,14 +47,15 @@ export default async function Page() {
       </div>
     </div>
 
-      <div className="relative mt-4 mx-auto w-full max-w-4xl aspect-[16/9] post-hero overflow-hidden rounded-xl border bg-gray-100">
+      <div className="mt-4 mx-auto w-full max-w-4xl overflow-hidden rounded-xl border bg-gray-100">
         <Image
           src={hero}
           alt={title}
-          fill
+          width={1280}
+          height={720}
           priority
           sizes="(max-width:768px) 100vw, 720px"
-          className={hero.includes("otolon_face") ? "object-contain" : "object-cover"}
+          className={`${hero.includes("otolon_face") ? "object-contain" : "object-cover"} w-full h-auto`}
         />
       </div>
 

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -1,5 +1,5 @@
 import Image from "next/image";
-import { cn } from "../lib/cn";
+import { cn } from "@/lib/cn";
 
 type CardProps = {
   slug: string;
@@ -11,21 +11,24 @@ type CardProps = {
 
 export default function PostCard({ slug, title, description, date, thumb }: CardProps) {
   const img = thumb || "/otolon_face.webp";
-  const isSquareFallback = img.includes("otolon_face");
+  const isSquareFallback = img.includes("/otolon_face");
 
   return (
     <a
       href={`/blog/posts/${slug}`}
       className="group block rounded-2xl border bg-white shadow-md transition hover:shadow-lg"
     >
-      {/* 画像ラッパー：ここで 16:9 を決める */}
-      <div className="relative aspect-[16/9] w-full overflow-hidden rounded-t-2xl bg-gray-50">
+      <div className="w-full overflow-hidden rounded-t-2xl bg-gray-50">
         <Image
-          src={img}
           alt={title}
-          fill
+          src={img}
+          width={1280}            // 16:9 の元解像度（任意でOK）
+          height={720}
           sizes="(max-width:640px) 100vw, 384px"
-          className={cn(isSquareFallback ? "object-contain" : "object-cover")}
+          className={cn(
+            isSquareFallback ? "object-contain" : "object-cover",
+            "w-full h-auto"
+          )}
           priority={false}
         />
       </div>


### PR DESCRIPTION
## Summary
- use explicit width/height and responsive classes for post cards
- convert homepage hero image to fixed dimensions
- drop legacy Next/Image span override from global CSS

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/eslint)*

------
https://chatgpt.com/codex/tasks/task_b_68a97e876f3883238287c70cf9cd10a8