### PR TITLE
Restrict hero and thumbnail image dimensions

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -47,15 +47,14 @@ export default async function Page() {
       </div>
     </div>
 
-      <div className="mt-4 mx-auto w-full max-w-4xl overflow-hidden rounded-xl border bg-gray-100">
+      <div className="relative mx-auto mt-4 w-full max-w-3xl overflow-hidden rounded-xl border bg-gray-100 aspect-[16/9] max-h-[320px] md:max-h-[380px]">
         <Image
           src={hero}
           alt={title}
-          width={1280}
-          height={720}
+          fill
           priority
-          sizes="(max-width:768px) 100vw, 720px"
-          className={`${hero.includes("otolon_face") ? "object-contain" : "object-cover"} w-full h-auto`}
+          sizes="(max-width:640px) 100vw, 768px"
+          className={hero.includes("otolon_face") ? "object-contain" : "object-cover"}
         />
       </div>
 

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -95,13 +95,13 @@ export default async function PostPage({ params }: { params: { slug: string } })
             </time>
 
             {/* ←親に 16/9 の“枠”＋最大幅を与えて画像を収める */}
-            <div className="relative mt-4 aspect-[16/9] w-full overflow-hidden rounded-xl border border-gray-100">
+            <div className="relative mx-auto mt-4 w-full max-w-3xl overflow-hidden rounded-xl border bg-gray-100 aspect-[16/9] max-h-[320px] md:max-h-[380px]">
               <Image
                 src={hero}
                 alt={post.title}
                 fill
-                priority
-                sizes="(max-width:768px) 100vw, 720px"
+                priority={false}
+                sizes="(max-width:640px) 100vw, 768px"
                 className={hero.includes("otolon_face") ? "object-contain" : "object-cover"}
               />
             </div>

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -14,19 +14,18 @@ export default function PostCard({ slug, title, description, date, thumb }: Card
       href={`/blog/posts/${slug}`}
       className="group block rounded-2xl border bg-white shadow-md transition hover:shadow-lg"
     >
-      <div className="w-full overflow-hidden rounded-t-2xl bg-gray-50">
+      <div className="relative w-full overflow-hidden rounded-t-2xl bg-gray-50 aspect-[16/9] max-h-44 sm:max-h-52">
         {thumb ? (
           <Image
             alt={title}
             src={thumb}
-            width={1280}
-            height={720}
+            fill
             sizes="(max-width:640px) 100vw, 384px"
-            className="w-full h-auto object-cover"
+            className="object-cover"
             priority={false}
           />
         ) : (
-          <div className="aspect-[16/9] w-full flex items-center justify-center text-gray-400">
+          <div className="flex h-full w-full items-center justify-center text-gray-400">
             <span className="text-xs">No thumbnail</span>
           </div>
         )}


### PR DESCRIPTION
## Summary
- limit post card thumbnail height and switch to `object-cover`
- constrain hero images on the homepage and post pages with fixed aspect ratio and max heights
- adjust responsive `sizes` for hero images

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a98591e51c8323b00a589304ba308d