### PR TITLE
Add img-reset utility for fill images

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -512,3 +512,13 @@ article h2, article h3 { scroll-margin-top: 96px; }
 /* もし過去の修正で「高さを決め打ち」していたクラスがあれば無効化 */
 /* 例: .post-hero { height: auto !important; } */
 
+/* ==== kill next/image fill の inline style（最終手段） ==== */
+/* これを付けた <Image className="img-reset" ... fill /> は、絶対配置を解除して通常の画像と同じ挙動にする */
+.img-reset[data-nimg="fill"]{
+  position: static !important;
+  inset: auto !important;
+  width: 100% !important;
+  height: auto !important;
+  color: transparent; /* 既存の透明はそのまま */
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -54,7 +54,7 @@ export default async function Page() {
           fill
           priority
           sizes="(max-width:640px) 100vw, 768px"
-          className={hero.includes("otolon_face") ? "object-contain" : "object-cover"}
+          className={`${hero.includes("otolon_face") ? "object-contain" : "object-cover"} img-reset`}
         />
       </div>
 

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -102,7 +102,7 @@ export default async function PostPage({ params }: { params: { slug: string } })
                 fill
                 priority={false}
                 sizes="(max-width:640px) 100vw, 768px"
-                className={hero.includes("otolon_face") ? "object-contain" : "object-cover"}
+                className={`${hero.includes("otolon_face") ? "object-contain" : "object-cover"} img-reset`}
               />
             </div>
           </header>

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -21,7 +21,7 @@ export default function PostCard({ slug, title, description, date, thumb }: Card
             src={thumb}
             fill
             sizes="(max-width:640px) 100vw, 384px"
-            className="object-cover"
+            className="object-cover img-reset"
             priority={false}
           />
         ) : (


### PR DESCRIPTION
## Summary
- add CSS rules to neutralize Next.js `fill` inline styles
- apply `img-reset` class to hero and card images

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a98abcc8408323aa729d00c12d11bd