### PR TITLE
Use Set#forEach for tag sitemap URLs

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -19,14 +19,20 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   if (posts.length) {
     const tags = new Set<string>();
     posts.forEach((p: any) => (p.tags ?? []).forEach((t: string) => tags.add(t)));
-    for (const tag of tags) {
+
+    // Set#forEach を使う or Array.from(tags).forEach でも可
+    tags.forEach((tag) => {
       tagUrls.push({
         url: `${base}/blog/tags/${encodeURIComponent(tag)}`,
         lastModified: new Date(),
         changeFrequency: 'weekly',
         priority: 0.5,
       });
-    }
+    });
+
+    // 安定化したければ並び替え（任意）
+    // const sorted = Array.from(tags).sort();
+    // sorted.forEach((tag) => { ...push... });
   }
 
   const staticUrls: MetadataRoute.Sitemap = [


### PR DESCRIPTION
## Summary
- replace `for...of` with `tags.forEach` when building tag URLs in the sitemap
- document optional sorting for stable tag order

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm ci` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_b_68a99ee878848323a652fcbf10ce2b29