### PR TITLE
Add JSON-LD structured data for blog posts

### DIFF
--- a/components/JsonLd.tsx
+++ b/components/JsonLd.tsx
@@ -1,0 +1,8 @@
+export default function JsonLd({ data }: { data: object }) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable `JsonLd` component for embedding JSON-LD
- include `BlogPosting` and `BreadcrumbList` JSON-LD on post pages with absolute URLs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/eslint)*

------
https://chatgpt.com/codex/tasks/task_b_68a9a114493c8323bd4d8f858684ae5c