### PR TITLE
Add metadata base and structured data for blog

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,16 +1,26 @@
-import Link from 'next/link';
-import PostCard from '@/components/PostCard';
-import { getPaginatedPosts } from '@/lib/posts';
+import Link from "next/link";
+import PostCard from "@/components/PostCard";
+import { getPaginatedPosts } from "@/lib/posts";
 
 const PAGE_SIZE = 10;
+const BASE =
+  process.env.NEXT_PUBLIC_SITE_URL || "https://otoron-blog.vercel.app";
 
 export const revalidate = 60;
 
-export default async function BlogIndexPage() {
+export default async function BlogTopPage() {
   const { items, total } = await getPaginatedPosts(0, PAGE_SIZE);
   const totalPages = Math.ceil(total / PAGE_SIZE);
 
+  const blogLd = {
+    "@context": "https://schema.org",
+    "@type": "Blog",
+    name: "オトロン公式ブログ",
+    url: `${BASE}/blog`,
+  };
+
   return (
+    <>
     <main className="mx-auto max-w-5xl px-4 py-12">
       <h1 className="text-2xl font-bold mb-6">記事一覧</h1>
 
@@ -34,6 +44,11 @@ export default async function BlogIndexPage() {
         </nav>
       )}
     </main>
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(blogLd) }}
+    />
+    </>
   );
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,14 @@
 import "./globals.css";
+import type { Metadata } from "next";
 import type { ReactNode } from "react";
 
-export const metadata = {
-  metadataBase: new URL("https://playotoron.com"),
+export const metadata: Metadata = {
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_SITE_URL || "https://otoron-blog.vercel.app"
+  ),
   themeColor: [
-    { media: '(prefers-color-scheme: light)', color: '#60A5FA' },
-    { media: '(prefers-color-scheme: dark)', color: '#111827' },
+    { media: "(prefers-color-scheme: light)", color: "#60A5FA" },
+    { media: "(prefers-color-scheme: dark)", color: "#111827" },
   ],
 };
 


### PR DESCRIPTION
## Summary
- configure metadataBase from `NEXT_PUBLIC_SITE_URL`
- add canonical, OGP fallback and JSON-LD to blog posts
- include Blog JSON-LD on index page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a9abc829308323954444cc4058052c