### PR TITLE
Refine hero and TOC handling on posts

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -28,6 +28,12 @@ kbd{background:#f6f6f6;border:1px solid #e4e4e7;border-bottom-width:2px;border-r
 .toc li.d3{margin-left:16px}
 .post :is(h2,h3) .anchor{margin-left:6px;text-decoration:none;opacity:.4}
 .post :is(h2,h3):hover .anchor{opacity:.9}
+
+/* 見出し末尾の「#」アンカーを非表示 */
+.prose h1 .anchor,
+.prose h2 .anchor,
+.prose h3 .anchor,
+.prose h4 .anchor { display: none; }
 html {
   scroll-behavior: smooth; /* TOCクリックで滑らかスクロール */
 }
@@ -115,8 +121,8 @@ html {
 }
 
 /* 見出しにアンカーで飛んだ時に被らないよう余白確保 */
-.prose h1, .prose h2, .prose h3, .prose h4, .prose h5, .prose h6 {
-  scroll-margin-top: 84px; /* ヘッダー固定時の被り防止 */
+.prose h1, .prose h2, .prose h3, .prose h4 {
+  scroll-margin-top: 96px; /* ヘッダの高さに合わせて調整 */
 }
 
 /* シンプル目次スタイル */

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -58,7 +58,7 @@ export default async function PostPage({ params }: { params: { slug: string } })
 
   const { prev, next }: any = await getAdjacentPosts(post.slug);
   const related = await getRelatedPosts(post.slug, 2);
-  const hero = post.thumb || post.ogImage || "/otolon_face.webp";
+  const hero = post.thumb ?? null;
   const canonical = `${BASE}/blog/posts/${post.slug}`;
   const ogImageAbs = `${BASE}${post.ogImage || "/ogp.png"}`;
 
@@ -95,6 +95,13 @@ export default async function PostPage({ params }: { params: { slug: string } })
     <>
       <main className="mx-auto max-w-5xl px-4 py-8">
         <div className={`grid grid-cols-1 gap-8 md:grid-cols-12`}>
+          {/* ▼ デスクトップ用（本文より前に配置） */}
+          {hasTOC && (
+            <aside className="hidden md:block md:col-span-4 toc-aside order-first">
+              <TableOfContents headings={post.headings} />
+            </aside>
+          )}
+
           {/* 本文（8カラム） */}
           <article className="md:col-span-8">
             <header className="mb-6">
@@ -103,30 +110,37 @@ export default async function PostPage({ params }: { params: { slug: string } })
                 {new Date(post.date).toLocaleDateString("ja-JP")}
               </time>
 
-              {/* ←親に 16/9 の“枠”＋最大幅を与えて画像を収める */}
-              <div className="relative mx-auto mt-4 w-full max-w-3xl overflow-hidden rounded-xl border bg-gray-100 aspect-[16/9] max-h-[320px] md:max-h-[380px]">
-                <Image
-                  src={hero}
-                  alt={post.title}
-                  fill
-                  priority={false}
-                  sizes="(max-width:640px) 100vw, 768px"
-                  className={`${hero.includes("otolon_face") ? "object-contain" : "object-cover"} img-reset`}
-                />
-              </div>
+              {hero && (
+                <div className="relative mx-auto mt-4 w-full max-w-3xl overflow-hidden rounded-xl border bg-gray-100 aspect-[16/9] max-h-[320px] md:max-h-[380px]">
+                  <Image
+                    src={hero}
+                    alt={post.title}
+                    fill
+                    priority={false}
+                    sizes="(max-width:640px) 100vw, 768px"
+                    className="object-cover img-reset"
+                  />
+                </div>
+              )}
             </header>
+            {hasTOC && (
+              <details className="md:hidden toc-mobile mb-4">
+                <summary className="toc-title">目次</summary>
+                <TableOfContents headings={post.headings} />
+              </details>
+            )}
 
-          {post.tags?.length > 0 && (
-            <ul className="mt-3 flex flex-wrap gap-2">
-              {post.tags.map((t: string) => (
-                <li key={t}>
-                  <a href={`/blog/tags/${tagSlug(t)}`} className="tag-chip">
-                    {t}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          )}
+            {post.tags?.length > 0 && (
+              <ul className="mt-3 flex flex-wrap gap-2">
+                {post.tags.map((t: string) => (
+                  <li key={t}>
+                    <a href={`/blog/tags/${tagSlug(t)}`} className="tag-chip">
+                      {t}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            )}
 
           {/* 本文は .prose 内だけ */}
           <div className="prose prose-blue max-w-none">
@@ -169,22 +183,7 @@ export default async function PostPage({ params }: { params: { slug: string } })
               </div>
             </section>
           )}
-
-          {/* モバイル TOC（本文に見出しが無い場合は非表示） */}
-          {hasTOC && (
-            <details className="md:hidden toc-mobile mt-10">
-              <summary className="toc-mobile-summary">目次</summary>
-              <TableOfContents headings={post.headings} />
-            </details>
-          )}
         </article>
-
-        {/* ▼ デスクトップ用 */}
-        <aside className="hidden md:block md:col-span-4">
-          <div className="sticky top-24 toc-aside">
-            <TableOfContents headings={post.headings} />
-          </div>
-        </aside>
       </div>
     </main>
     <script

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -109,11 +109,7 @@ export async function renderMarkdown(
     .use(rehypeSlug)
     .use(collectToc) // ← 先に見出しを収集（rehypeSlug 後）
     .use(rehypeAutolinkHeadings, {
-      behavior: "append",
-      content: {
-        type: "text",
-        value: " #",
-      },
+      behavior: "wrap",
     })
     .use(rehypeExternalLinks)
     .use(rehypeSanitize, schema as any)


### PR DESCRIPTION
## Summary
- Display hero image only when a post thumbnail is provided
- Show table of contents before the article and hide autolink anchor markers
- Wrap markdown headings for stable TOC linking

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: next: not found; dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_b_68aaeacd4a84832384472a3d9cef1fa2