### PR TITLE
feat: refine table-of-contents styling and anchors

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -84,6 +84,10 @@ html {
   display: block;
   margin: 0 0 1rem;
 }
+.toc-mobile > summary {
+  cursor: pointer;
+  font-weight: 700;
+}
 .toc-details {
   border: 1px solid rgba(0,0,0,.08);
   border-radius: .5rem;
@@ -173,6 +177,19 @@ main { padding-top: 24px; }
 .toc-aside nav.toc { font-size: 14px; }
 .toc-aside a { color: var(--brand); text-decoration: none; }
 .toc-aside a:hover { text-decoration: underline; }
+
+/* 目次ボックス（サイド）のベース */
+.toc-box {
+  position: sticky;
+  top: 96px;                /* ヘッダー高さに合わせて調整 */
+  z-index: 10;
+  background: var(--bg, #fff);
+  border: 1px solid #e5e7eb; /* #eee でも可 */
+  border-radius: 12px;
+  max-height: calc(100vh - 120px);
+  overflow: auto;
+  padding: 12px;
+}
 
 /* ==== Blog minimal refresh (SEO-first) ==== */
 :root{

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -94,16 +94,22 @@ export default async function PostPage({ params }: { params: { slug: string } })
   return (
     <>
       <main className="mx-auto max-w-5xl px-4 py-8">
+        {hasTOC && (
+          <details className="md:hidden toc-mobile mb-6">
+            <summary>目次</summary>
+            <TableOfContents headings={post.headings} />
+          </details>
+        )}
         <div className={`grid grid-cols-1 gap-8 md:grid-cols-12`}>
-          {/* ▼ デスクトップ用（本文より前に配置） */}
           {hasTOC && (
-            <aside className="hidden md:block md:col-span-4 toc-aside order-first">
-              <TableOfContents headings={post.headings} />
+            <aside className="hidden md:block md:col-span-4 order-first">
+              <div className="toc-box">
+                <TableOfContents headings={post.headings} />
+              </div>
             </aside>
           )}
 
-          {/* 本文（8カラム） */}
-          <article className="md:col-span-8">
+          <article className="md:col-span-8 prose prose-blue max-w-none">
             <header className="mb-6">
               <h1 className="text-2xl font-bold">{post.title}</h1>
               <time className="mt-2 block text-sm text-gray-500">
@@ -123,12 +129,6 @@ export default async function PostPage({ params }: { params: { slug: string } })
                 </div>
               )}
             </header>
-            {hasTOC && (
-              <details className="md:hidden toc-mobile mb-4">
-                <summary className="toc-title">目次</summary>
-                <TableOfContents headings={post.headings} />
-              </details>
-            )}
 
             {post.tags?.length > 0 && (
               <ul className="mt-3 flex flex-wrap gap-2">
@@ -142,55 +142,50 @@ export default async function PostPage({ params }: { params: { slug: string } })
               </ul>
             )}
 
-          {/* 本文は .prose 内だけ */}
-          <div className="prose prose-blue max-w-none">
             <div dangerouslySetInnerHTML={{ __html: post.html }} />
-          </div>
 
-          {/* 前後記事 …（既存のまま） */}
-          <nav className="mt-10 flex justify-between text-sm">
-            <div>
-              {prev && (
-                <a href={`/blog/posts/${prev.slug}`} className="underline">
-                  ← {prev.title}
-                </a>
-              )}
-            </div>
-            <div>
-              {next && (
-                <a href={`/blog/posts/${next.slug}`} className="underline">
-                  {next.title} →
-                </a>
-              )}
-            </div>
-          </nav>
-
-          {/* 関連記事 */}
-          {related?.length > 0 && (
-            <section aria-labelledby="related" className="mt-12">
-              <h2 id="related" className="text-lg font-semibold">関連記事</h2>
-              <div className="mt-4 grid grid-cols-1 gap-6 sm:grid-cols-2">
-                {related.map((p: any) => (
-                  <PostCard
-                    key={p.slug}
-                    slug={p.slug}
-                    title={p.title}
-                    description={p.description}
-                    date={p.date}
-                    thumb={p.thumb}
-                  />
-                ))}
+            <nav className="mt-10 flex justify-between text-sm">
+              <div>
+                {prev && (
+                  <a href={`/blog/posts/${prev.slug}`} className="underline">
+                    ← {prev.title}
+                  </a>
+                )}
               </div>
-            </section>
-          )}
-        </article>
-      </div>
-    </main>
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(articleLd) }}
-    />
-    <script
+              <div>
+                {next && (
+                  <a href={`/blog/posts/${next.slug}`} className="underline">
+                    {next.title} →
+                  </a>
+                )}
+              </div>
+            </nav>
+
+            {related?.length > 0 && (
+              <section aria-labelledby="related" className="mt-12">
+                <h2 id="related" className="text-lg font-semibold">関連記事</h2>
+                <div className="mt-4 grid grid-cols-1 gap-6 sm:grid-cols-2">
+                  {related.map((p: any) => (
+                    <PostCard
+                      key={p.slug}
+                      slug={p.slug}
+                      title={p.title}
+                      description={p.description}
+                      date={p.date}
+                      thumb={p.thumb}
+                    />
+                  ))}
+                </div>
+              </section>
+            )}
+          </article>
+        </div>
+      </main>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleLd) }}
+      />
+      <script
       type="application/ld+json"
       dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
     />

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -24,9 +24,6 @@ function estimateJaMinutes(md) {
   return Math.max(1, Math.round(chars / CPM));
 }
 
-const slugify = (s) =>
-  s.trim().toLowerCase().replace(/\s+/g, '-').replace(/[^\w\-]/g, '');
-
 const normalizeTags = (tags) => {
   if (!tags) return [];
   if (Array.isArray(tags)) return tags.map(String).map((s) => s.trim()).filter(Boolean);
@@ -35,38 +32,6 @@ const normalizeTags = (tags) => {
     .map((s) => s.trim())
     .filter(Boolean);
 };
-
-function extractHeadingsFromMarkdown(md) {
-  const lines = md.split('\n');
-  const hs = [];
-  for (const line of lines) {
-    const m2 = line.match(/^##\s+(.+)/);
-    const m3 = line.match(/^###\s+(.+)/);
-    if (m2) hs.push({ depth: 2, text: m2[1].trim(), id: slugify(m2[1]) });
-    if (m3) hs.push({ depth: 3, text: m3[1].trim(), id: slugify(m3[1]) });
-  }
-  return hs;
-}
-
-// HTML文字列の <h2>/<h3> に id を埋め込む（同じslugなら上書き）
-function injectIdsToHtmlHeadings(html, headings) {
-  let out = html;
-  for (const h of headings) {
-    if (h.depth === 2) {
-      out = out.replace(
-        new RegExp(`<h2>(\\s*?)${h.text.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&')}(\\s*?)<\/h2>`),
-        `<h2 id="${h.id}">$1${h.text}$2</h2>`
-      );
-    }
-    if (h.depth === 3) {
-      out = out.replace(
-        new RegExp(`<h3>(\\s*?)${h.text.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&')}(\\s*?)<\/h3>`),
-        `<h3 id="${h.id}">$1${h.text}$2</h3>`
-      );
-    }
-  }
-  return out;
-}
 
 // posts/ 内のMarkdownファイル一覧を取得（READMEと"_"始まりは無視）
 function listPostFiles() {
@@ -191,11 +156,9 @@ export async function getPostBySlug(slug) {
   const p = getPost(slug);
   if (!p) return null;
   const md = p.content;
-  const headings = extractHeadingsFromMarkdown(md);
   const minutes = estimateJaMinutes(md);
-  const { html } = await renderMarkdown(md);
-  const htmlWithIds = injectIdsToHtmlHeadings(html, headings);
-  return { ...p, html: htmlWithIds, headings, readingMinutes: minutes };
+  const { html, headings } = await renderMarkdown(md);
+  return { ...p, html, headings, readingMinutes: minutes };
 }
 
 // 前後ナビ（非同期ラッパー）


### PR DESCRIPTION
## Summary
- style TOC summary and add sticky desktop TOC box
- render headings with consistent slugs and layout updates for posts
- improve fallback slug creation for client TOC

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68aaefaac6648323bfef97b115c54c68