### PR TITLE
Fix ToC scrolling and tag routing

### DIFF
--- a/app/blog/tags/[tag]/page.tsx
+++ b/app/blog/tags/[tag]/page.tsx
@@ -1,33 +1,31 @@
 import { notFound } from "next/navigation";
-import PostCard from "@/components/PostCard";
 import { getAllPostsMeta } from "@/lib/posts";
+
+export const revalidate = 300; // ISR 任意
+export const dynamic = "force-static"; // 任意
 
 export async function generateStaticParams() {
   const posts = await getAllPostsMeta();
   const set = new Set<string>();
-  posts.forEach(p => (p.tags ?? []).forEach((t: string) => set.add(t)));
-  return Array.from(set).map(tag => ({ tag }));
+  posts.forEach((p) => (p.tags ?? []).forEach((t: string) => set.add(String(t))));
+  // ★ ここは「エンコードしない」そのまま返す
+  return Array.from(set).map((tag) => ({ tag }));
 }
 
 export default async function TagPage({ params }: { params: { tag: string } }) {
-  const posts = (await getAllPostsMeta()).filter(p => (p.tags ?? []).includes(params.tag));
-  if (!posts.length) return notFound();
-
+  const tag = params.tag; // Next 側ですでに decode 済み
+  const posts = (await getAllPostsMeta()).filter((p) => (p.tags ?? []).includes(tag));
+  if (posts.length === 0) return notFound();
   return (
-    <main className="mx-auto max-w-5xl px-4 py-12">
-      <h1 className="text-2xl font-bold mb-6">タグ: {params.tag}</h1>
-      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
-        {posts.map(p => (
-          <PostCard
-            key={p.slug}
-            slug={p.slug}
-            title={p.title}
-            description={p.description}
-            date={p.date}
-            thumb={p.thumb}
-          />
+    <main className="container prose">
+      <h1>#{tag}</h1>
+      <ul>
+        {posts.map((p) => (
+          <li key={p.slug}>
+            <a href={`/blog/posts/${p.slug}`}>{p.title}</a>
+          </li>
         ))}
-      </div>
+      </ul>
     </main>
   );
 }

--- a/app/blog/tags/page.tsx
+++ b/app/blog/tags/page.tsx
@@ -12,7 +12,7 @@ export default async function TagsPage() {
         {tags.map(t => (
           <li key={t.slug}>
             <Link
-              href={`/blog/tags/${t.slug}`}
+              href={`/blog/tags/${encodeURIComponent(t.name)}`}
               className="inline-block rounded-full border px-3 py-1 text-sm hover:bg-gray-50"
             >
               {t.name} <span className="text-gray-400">({t.count})</span>

--- a/app/globals.css
+++ b/app/globals.css
@@ -556,3 +556,7 @@ a:hover {
 .toc a { color: inherit; text-decoration: none; }
 .toc a:hover { color: var(--brand, #2563eb); text-decoration: underline; }
 .brand { color: var(--brand); }
+
+/* 一覧のタイトルを落ち着かせる */
+.post-list h2 a { color: inherit; text-decoration: none; }
+.post-list h2 a:hover { text-decoration: underline; }

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -7,7 +7,6 @@ import {
   getAdjacentPosts,
   getRelatedPosts,
 } from "@/lib/posts";
-import { tagSlug } from "@/lib/tags";
 import PostCard from "@/components/PostCard";
 import TableOfContents from "@/components/TableOfContents";
 
@@ -134,7 +133,7 @@ export default async function PostPage({ params }: { params: { slug: string } })
               <ul className="mt-3 flex flex-wrap gap-2">
                 {post.tags.map((t: string) => (
                   <li key={t}>
-                    <a href={`/blog/tags/${tagSlug(t)}`} className="tag-chip">
+                    <a href={`/blog/tags/${encodeURIComponent(t)}`} className="tag-chip">
                       {t}
                     </a>
                   </li>

--- a/components/TableOfContents.tsx
+++ b/components/TableOfContents.tsx
@@ -2,12 +2,18 @@
 
 type TocItem = { level: number; title: string; id: string };
 
+const HEADER_OFFSET = 96; // ヘッダーの高さに合わせて調整
+
 export default function TableOfContents({ headings }: { headings: TocItem[] }) {
-  const onClick = (e: React.MouseEvent<HTMLAnchorElement>, id: string) => {
+  const handleClick = (
+    e: React.MouseEvent<HTMLAnchorElement>,
+    id: string
+  ) => {
     e.preventDefault();
-    const el = document.getElementById(decodeURIComponent(id));
+    const el = document.getElementById(id); // decode しない
     if (el) {
-      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      const y = el.getBoundingClientRect().top + window.scrollY - HEADER_OFFSET;
+      window.scrollTo({ top: y, behavior: 'smooth' });
       history.replaceState(null, '', `#${id}`);
     }
   };
@@ -17,7 +23,7 @@ export default function TableOfContents({ headings }: { headings: TocItem[] }) {
       <ul>
         {headings.map((h) => (
           <li key={h.id} className={`lvl-${h.level}`}>
-            <a href={`#${h.id}`} onClick={(e) => onClick(e, h.id)}>
+            <a href={`#${h.id}`} onClick={(e) => handleClick(e, h.id)}>
               {h.title}
             </a>
           </li>


### PR DESCRIPTION
## Summary
- ensure table of contents links scroll smoothly with header offset
- encode tag URLs and add dynamic tag page
- style anchors and TOC, adjust post list links

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ab00f955c88323ba204107b2506edb