### PR TITLE
feat: unify tag links and styling

### DIFF
--- a/app/blog/tags/[tag]/page.tsx
+++ b/app/blog/tags/[tag]/page.tsx
@@ -3,6 +3,7 @@ import { getAllPostsMeta } from "@/lib/posts";
 
 export const revalidate = 300; // ISR 任意
 export const dynamic = "force-static"; // 任意
+export const dynamicParams = true;
 
 export async function generateStaticParams() {
   const posts = await getAllPostsMeta();
@@ -22,7 +23,9 @@ export default async function TagPage({ params }: { params: { tag: string } }) {
       <ul>
         {posts.map((p) => (
           <li key={p.slug}>
-            <a href={`/blog/posts/${p.slug}`}>{p.title}</a>
+            <a href={`/blog/posts/${p.slug}`} className="link-plain">
+              {p.title}
+            </a>
           </li>
         ))}
       </ul>

--- a/app/blog/tags/page.tsx
+++ b/app/blog/tags/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { getAllTags } from "@/lib/tags";
+import TagChip from "@/components/TagChip";
 
 export const metadata = { title: "タグ一覧 | オトロンブログ" };
 
@@ -9,14 +9,11 @@ export default async function TagsPage() {
     <main className="mx-auto max-w-5xl px-4 py-12">
       <h1 className="text-2xl font-bold mb-6">タグ一覧</h1>
       <ul className="flex flex-wrap gap-3">
-        {tags.map(t => (
+        {tags.map((t) => (
           <li key={t.slug}>
-            <Link
-              href={`/blog/tags/${encodeURIComponent(t.name)}`}
-              className="inline-block rounded-full border px-3 py-1 text-sm hover:bg-gray-50"
-            >
-              {t.name} <span className="text-gray-400">({t.count})</span>
-            </Link>
+            <TagChip tag={t.name}>
+              <span className="ml-1 text-gray-400">({t.count})</span>
+            </TagChip>
           </li>
         ))}
       </ul>

--- a/app/globals.css
+++ b/app/globals.css
@@ -488,16 +488,15 @@ h1.page-title{ font-size:clamp(28px,5vw,40px); line-height:1.2; margin:24px 0 8p
 /* 見出しのアンカーずれ対策（ヘッダー分の余白） */
 article h2, article h3 { scroll-margin-top: 96px; }
 
-.tag-chip {
-  display: inline-block;
-  padding: .25rem .6rem;
-  border: 1px solid #e5e7eb;
-  border-radius: 9999px;
-  background: #fff;
-  font-size: .85rem;
-  line-height: 1;
+.link-plain {
+  color: inherit;
+  text-decoration: none;
 }
-.tag-chip:hover { background: #f8fafc; }
+.link-plain:hover {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
 
 /* 本文(prose)内の画像がレイアウトを壊さないように */
 .prose img {

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/lib/posts";
 import PostCard from "@/components/PostCard";
 import TableOfContents from "@/components/TableOfContents";
+import TagChip from "@/components/TagChip";
 
 const BASE =
   process.env.NEXT_PUBLIC_SITE_URL || "https://otoron-blog.vercel.app";
@@ -133,9 +134,7 @@ export default async function PostPage({ params }: { params: { slug: string } })
               <ul className="mt-3 flex flex-wrap gap-2">
                 {post.tags.map((t: string) => (
                   <li key={t}>
-                    <a href={`/blog/tags/${encodeURIComponent(t)}`} className="tag-chip">
-                      {t}
-                    </a>
+                    <TagChip tag={t} />
                   </li>
                 ))}
               </ul>

--- a/components/TagChip.tsx
+++ b/components/TagChip.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+export default function TagChip({ tag, children }: { tag: string; children?: React.ReactNode }) {
+  return (
+    <a
+      href={`/blog/tags/${encodeURIComponent(tag)}`}
+      className="inline-flex items-center rounded-full bg-gray-100 px-2 py-1 text-sm text-gray-700 no-underline hover:underline hover:bg-gray-200"
+    >
+      {tag}
+      {children}
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable `TagChip` component for tags
- use new `link-plain` utility to neutralize default link colors
- allow dynamic params on tag pages to reduce 404s

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ab0928c7e8832394cd0e803e07f54b