### PR TITLE
Fix tag page metadata and unify link styling

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -40,7 +40,7 @@ export default async function BlogTopPage() {
       {totalPages > 1 && (
         <nav className="mt-10 flex items-center justify-between">
           <span />
-          <Link className="underline" href="/blog/page/2">次のページ →</Link>
+          <Link className="link-plain" href="/blog/page/2">次のページ →</Link>
         </nav>
       )}
     </main>

--- a/app/blog/page/[page]/page.tsx
+++ b/app/blog/page/[page]/page.tsx
@@ -40,11 +40,11 @@ export default async function BlogPagedPage({ params }: { params: { page: string
       </div>
 
       <nav className="mt-10 flex items-center justify-between">
-        <Link className="underline" href={pageNum === 2 ? '/blog' : `/blog/page/${pageNum - 1}`}>
+        <Link className="link-plain" href={pageNum === 2 ? '/blog' : `/blog/page/${pageNum - 1}`}>
           ← 前のページ
         </Link>
         {pageNum < totalPages
-          ? <Link className="underline" href={`/blog/page/${pageNum + 1}`}>次のページ →</Link>
+          ? <Link className="link-plain" href={`/blog/page/${pageNum + 1}`}>次のページ →</Link>
           : <span />
         }
       </nav>

--- a/app/globals.css
+++ b/app/globals.css
@@ -252,7 +252,14 @@ main { padding-top: 24px; }
 .prose h3{margin: 22px 0 8px; font-size: 18px;}
 .prose p{line-height: 1.9; margin: 12px 0;}
 .prose ul, .prose ol{margin: 12px 0 12px 1.25em;}
-.prose a{color: var(--brand); text-decoration: underline; text-decoration-color: var(--brand-600);}
+ .prose a {
+  color: inherit;
+  text-decoration: none;
+ }
+ .prose a:hover {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+ }
 .prose img{max-width: 100%; height: auto; border-radius: 8px;}
 
 .pn{

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,10 +18,10 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <body>
         <header className="mast">
           <div className="container">
-            <a className="brand" href="/">オトロン</a>
+            <a className="brand link-plain" href="/">オトロン</a>
             <nav>
-              <a href="/blog">記事一覧</a>
-              <a href="https://playotoron.com">公式サイト</a>
+              <a href="/blog" className="link-plain">記事一覧</a>
+              <a href="https://playotoron.com" className="link-plain">公式サイト</a>
             </nav>
           </div>
         </header>

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -145,14 +145,14 @@ export default async function PostPage({ params }: { params: { slug: string } })
             <nav className="mt-10 flex justify-between text-sm">
               <div>
                 {prev && (
-                  <a href={`/blog/posts/${prev.slug}`} className="underline">
+                  <a href={`/blog/posts/${prev.slug}`} className="link-plain">
                     ← {prev.title}
                   </a>
                 )}
               </div>
               <div>
                 {next && (
-                  <a href={`/blog/posts/${next.slug}`} className="underline">
+                  <a href={`/blog/posts/${next.slug}`} className="link-plain">
                     {next.title} →
                   </a>
                 )}

--- a/components/Breadcrumb.tsx
+++ b/components/Breadcrumb.tsx
@@ -6,7 +6,7 @@ export default function Breadcrumb({ items }: { items: Crumb[] }) {
       {items.map((c, i) => (
         <span key={i}>
           {c.href ? (
-            <a href={c.href} className="brand">{c.label}</a>
+            <a href={c.href} className="brand link-plain">{c.label}</a>
           ) : (
             <span className="current">{c.label}</span>
           )}

--- a/components/TableOfContents.tsx
+++ b/components/TableOfContents.tsx
@@ -23,7 +23,11 @@ export default function TableOfContents({ headings }: { headings: TocItem[] }) {
       <ul>
         {headings.map((h) => (
           <li key={h.id} className={`lvl-${h.level}`}>
-            <a href={`#${h.id}`} onClick={(e) => handleClick(e, h.id)}>
+            <a
+              href={`#${h.id}`}
+              onClick={(e) => handleClick(e, h.id)}
+              className="link-plain"
+            >
               {h.title}
             </a>
           </li>

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -82,10 +82,10 @@ function readPostMeta(file) {
   const raw = fs.readFileSync(path.join(POSTS_DIR, file), "utf8");
   const { data, content } = matter(raw);
 
-  const p = { slug, ...data };
+  // include tags so that tag pages can filter properly
+  const p = { slug, ...data, tags: normalizeTags(data.tags) };
   assertFrontMatter(p);
 
-  p.tags = normalizeTags(data.tags);
   p.readingMinutes = estimateJaMinutes(content);
   p.featured = Boolean(p.featured);
 
@@ -112,7 +112,9 @@ export function getAllPosts() {
 
 // 全投稿メタ情報（contentなし）
 export function getAllPostsMeta() {
-  return listPostFiles().map(readPostMeta);
+  return listPostFiles()
+    .map(readPostMeta)
+    .sort((a, b) => (a.date > b.date ? -1 : 1));
 }
 
 // 追加: ページング用スライス

--- a/types/posts.d.ts
+++ b/types/posts.d.ts
@@ -8,7 +8,7 @@ declare module "@/lib/posts" {
     ogImage?: string;
     thumb?: string;
     featured?: boolean;
-    tags?: string[];
+    tags: string[];
     draft?: boolean;
     readingMinutes?: number;
   };


### PR DESCRIPTION
## Summary
- include tags in post metadata and sort meta list to prevent tag page 404s
- unify link presentation across site with a `.link-plain` utility and neutral prose link styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ab104f4b348323a169dcd37c56cf7e