### PR TITLE
Refine layout, cards and article image handling

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -11,7 +11,7 @@ export default async function BlogIndex() {
       <div className="mx-auto max-w-6xl px-4 py-10">
         <h1 className="text-2xl font-bold text-[color:var(--ink)] heading-underline">記事一覧</h1>
 
-        <div className="mt-8 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+        <div className="mt-8 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
           {posts.map(p => <PostCard key={p.slug} post={p} />)}
         </div>
       </div>

--- a/app/blog/page/[page]/page.tsx
+++ b/app/blog/page/[page]/page.tsx
@@ -27,7 +27,7 @@ export default async function BlogPagedPage({ params }: { params: { page: string
       <div className="mx-auto max-w-6xl px-4 py-10">
         <h1 className="text-2xl font-bold text-[color:var(--ink)] heading-underline">記事一覧（{pageNum} / {totalPages}）</h1>
 
-        <div className="mt-8 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+        <div className="mt-8 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
           {items.map(p => (
             <PostCard key={p.slug} post={p} />
           ))}

--- a/app/blog/tags/page.tsx
+++ b/app/blog/tags/page.tsx
@@ -6,17 +6,19 @@ export const metadata = { title: "タグ一覧 | オトロンブログ" };
 export default async function TagsPage() {
   const tags = await getAllTags(); // { slug, name, count }[]
   return (
-    <main className="mx-auto max-w-5xl px-4 py-12">
-      <h1 className="text-2xl font-bold mb-6">タグ一覧</h1>
-      <ul className="flex flex-wrap gap-3">
-        {tags.map((t) => (
-          <li key={t.slug}>
-            <TagChip tag={t.name}>
-              <span>({t.count})</span>
-            </TagChip>
-          </li>
-        ))}
-      </ul>
+    <main className="bg-page">
+      <div className="mx-auto max-w-5xl px-4 py-12">
+        <h1 className="text-2xl font-bold mb-6">タグ一覧</h1>
+        <ul className="flex flex-wrap gap-3">
+          {tags.map((t) => (
+            <li key={t.slug}>
+              <TagChip tag={t.name}>
+                <span>({t.count})</span>
+              </TagChip>
+            </li>
+          ))}
+        </ul>
+      </div>
     </main>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,18 +1,19 @@
 *{box-sizing:border-box}
 html,body{margin:0;padding:0;background:var(--bg);color:var(--ink);font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,"Apple Color Emoji","Segoe UI Emoji";}
 
-/* 画像が親幅を超えて暴れないための保険 */
+/* 画像が親幅を超えて暴れないように */
 img, picture, video, canvas, svg { max-width: 100%; height: auto; }
 
+/* prose内の画像が親幅を超えないように */
+.prose img{max-width:100%;height:auto;border-radius:12px}
 
-/* prose(typography) 使用時も高さが固定化されないように */
-.prose img { height: auto; }
+.bg-page{
+  background-image: linear-gradient(to bottom, #fff 0%, #f8fafc 100%);
+}
 a:focus-visible{outline:2px solid var(--brand-600);outline-offset:2px}
 .container{max-width:920px;margin-inline:auto;padding:24px}
 .hero{font-size:40px;font-weight:900;letter-spacing:.01em;margin:8px 0 4px}
 .sub{color:var(--muted);margin:0 0 24px}
-.card{border:1px solid #eee;border-radius:16px;padding:16px;transition:box-shadow .2s,border-color .2s}
-.card:hover{box-shadow:0 6px 24px rgba(0,0,0,.06);border-color:#e4e4e7}
 .meta{font-size:12px;color:var(--muted);margin-top:4px}
 .post h2{margin-top:28px;border-left:4px solid var(--brand);padding-left:10px}
 .post img{max-width:100%;height:auto;border-radius:12px}
@@ -52,10 +53,6 @@ kbd{background:#f6f6f6;border:1px solid #e4e4e7;border-bottom-width:2px;border-r
 .prose th, .prose td {
   border: 1px solid rgba(0,0,0,.08);
   padding: .5rem .75rem;
-}
-.prose img {
-  max-width: 100%;
-  height: auto;
 }
 
 /* TOC 共通 */
@@ -187,7 +184,7 @@ main { padding-top: 24px; }
 
 /* ==== Blog minimal refresh (SEO-first) ==== */
 :root{
-  --brand: #6c46ff;
+  --brand: #2563eb;
   --brand-600: color-mix(in oklab, var(--brand), black 16%);
   --brand-100: color-mix(in oklab, var(--brand), white 82%);
   --brand-ink: #fff;
@@ -267,7 +264,6 @@ main { padding-top: 24px; }
   text-decoration: underline;
   text-underline-offset: 3px;
  }
-.prose img{max-width: 100%; height: auto; border-radius: 8px;}
 
 .pn{
   display:grid;
@@ -355,7 +351,7 @@ h1.page-title{ font-size:clamp(28px,5vw,40px); line-height:1.2; margin:24px 0 8p
 .pn a{ flex:1; display:block; background:var(--surface); border-radius:var(--radius);
        box-shadow:var(--shadow); padding:14px 16px; }
 :root{
-  --brand:#2b6bed;
+  --brand:#2563eb;
   --ink:#111;
   --muted:#6b7280;
   --surface:#fff;
@@ -542,13 +538,6 @@ article h2, article h3 { scroll-margin-top: 96px; }
 }
 
 
-/* 本文(prose)内の画像がレイアウトを壊さないように */
-.prose img {
-  max-width: 100%;
-  height: auto;
-  border-radius: 0.75rem; /* 12px 相当 */
-}
-
 /* ---- reveal once ---- */
 .reveal {
   opacity: 0;
@@ -610,11 +599,6 @@ a:hover {
   --muted:#6b7280;
   --surface:#ffffff;
   --surface-weak:#f8fafc;   /* slate-50 */
-}
-
-/* ページの淡いグラデ背景 */
-.bg-page{
-  background-image: linear-gradient(to bottom, #ffffff 0%, var(--surface-weak) 100%);
 }
 
 /* 共通カード（一覧/本文） */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,8 +15,8 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="ja">
-      <body>
-        <header className="site-header">
+      <body className="bg-page">
+        <header className="site-header sticky top-0 z-50 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 border-b">
           <div className="container">
             <a className="brand link-plain" href="/">オトロン</a>
             <nav>
@@ -25,8 +25,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             </nav>
           </div>
         </header>
-
-        <main className="container">{children}</main>
+        {children}
 
         <footer className="foot">
           <div className="container">© {new Date().getFullYear()} OTORON</div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,16 +18,18 @@ export default async function BlogIndexPage() {
   const { items, total, nextOffset } = await getPaginatedPosts(0, PAGE_SIZE);
 
   return (
-    <main className="mx-auto max-w-5xl px-4 py-12">
-      <h1 className="text-2xl font-bold mb-6">記事一覧</h1>
+    <main className="bg-page">
+      <div className="mx-auto max-w-5xl px-4 py-12">
+        <h1 className="text-2xl font-bold mb-6">記事一覧</h1>
 
-      <InfinitePosts
-        initialItems={items}
-        initialOffset={nextOffset}
-        total={total}
-        pageSize={PAGE_SIZE}
-        gridClassName="mt-8 grid grid-cols-1 gap-6 sm:grid-cols-2"
-      />
+        <InfinitePosts
+          initialItems={items}
+          initialOffset={nextOffset}
+          total={total}
+          pageSize={PAGE_SIZE}
+          gridClassName="mt-8 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3"
+        />
+      </div>
     </main>
   );
 }

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -94,7 +94,7 @@ export default async function PostPage({ params }: { params: { slug: string } })
   return (
     <>
       <main className="bg-page">
-        <div className="mx-auto max-w-5xl px-4 py-8">
+        <div className="mx-auto max-w-3xl px-4 py-10">
           {hasTOC && (
             <details className="md:hidden toc-mobile mb-6">
               <summary>目次</summary>
@@ -110,7 +110,7 @@ export default async function PostPage({ params }: { params: { slug: string } })
               </aside>
             )}
 
-            <article className="md:col-span-8 card prose prose-neutral md:prose-lg max-w-none p-6">
+            <article className="md:col-span-8 card prose prose-neutral md:prose-lg p-6">
               <header className="mb-6">
                 <h1 className="text-2xl font-bold">{post.title}</h1>
                 <time className="mt-2 block text-sm text-[color:var(--muted)]">

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -7,27 +7,27 @@ export default function PostCard({ post }: { post: any }) {
   return (
     <article className="card overflow-hidden">
       <a href={href} className="block">
-        <div className="relative w-full h-[180px] md:h-[200px]">
-          <Image
-            src={src}
-            alt={post.title}
-            fill
-            sizes="(max-width: 768px) 100vw, (max-width: 1024px) 33vw, 300px"
-            className="object-cover"
-            priority={false}
-          />
-        </div>
+        {/* 16:9 / 高さ 約180〜200px 相当 */}
+        <Image
+          src={src}
+          alt={post.title}
+          width={640}
+          height={360}
+          sizes="(max-width:640px) 100vw, (max-width:1024px) 33vw, 300px"
+          className="w-full h-auto object-cover"
+          priority={false}
+        />
       </a>
 
       <div className="p-4">
         <a href={href} className="link-plain">
           <h2 className="text-base md:text-lg font-semibold leading-snug line-clamp-2">{post.title}</h2>
         </a>
-        <p className="mt-2 text-sm text-[color:var(--muted)] line-clamp-2">{post.description}</p>
+        <p className="mt-2 text-sm text-gray-500 line-clamp-2">{post.description}</p>
 
         {post.tags?.length > 0 && (
           <div className="mt-3 flex flex-wrap gap-2">
-            {post.tags.slice(0,3).map((t: string) => (
+            {post.tags.slice(0,3).map((t:string)=> (
               <a key={t} href={`/blog/tags/${encodeURIComponent(t)}`} className="tag-chip">{t}</a>
             ))}
           </div>

--- a/components/TableOfContents.tsx
+++ b/components/TableOfContents.tsx
@@ -19,7 +19,7 @@ export default function TableOfContents({ headings }: { headings: TocItem[] }) {
   };
 
   return (
-    <nav aria-label="目次" className="toc">
+    <nav aria-label="目次" className="toc z-40">
       <ul>
         {headings.map((h) => (
           <li key={h.id} className={`lvl-${h.level}`}>


### PR DESCRIPTION
## Summary
- Pin header with translucent background and border for consistent navigation
- Tame post body width and prevent oversized images with new global styles
- Shrink blog listing cards and switch to fixed-size thumbnails for lighter layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found)*
- `npm ci` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_b_68ac69dfd27c8323b767fc938f3736f9