### PR TITLE
Fix blog list layout and card image ratio

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -12,8 +12,13 @@ export default async function BlogIndex() {
         <h1 className="text-2xl font-bold heading-underline">記事一覧</h1>
 
         {/* auto-fill + minmax で常に複数カラム化 */}
-        <div className="mt-8 grid gap-8 [grid-template-columns:repeat(auto-fill,minmax(320px,1fr))]">
-          {posts.map((p) => <PostCard key={p.slug} post={p} />)}
+        <div
+          className="mt-8 grid gap-8"
+          style={{ gridTemplateColumns: "repeat(auto-fill, minmax(320px, 1fr))" }}
+        >
+          {posts.map((p) => (
+            <PostCard key={p.slug} post={p} />
+          ))}
         </div>
       </div>
     </main>

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -5,22 +5,22 @@ export default function PostCard({ post }: { post: any }) {
   const src = post.thumb ?? "/images/no-thumb.png";
 
   return (
-    <article className="card overflow-hidden flex flex-col">
+    <article className="card overflow-hidden">
       <a href={href} className="block">
-        {/* 高さを器で固定 → 画像はfillで中に収める（巨大化しない） */}
-        <div className="relative w-full h-[180px] md:h-[200px]">
+        {/* 16:9 の器 + 最大200pxでクランプ */}
+        <div className="relative aspect-[16/9] w-full max-h-[200px]">
           <Image
             src={src}
             alt={post.title}
             fill
-            sizes="(min-width:1024px) 33vw, (min-width:640px) 50vw, 100vw"
             className="object-cover"
+            sizes="(min-width:1024px) 33vw, (min-width:640px) 50vw, 100vw"
             priority={false}
           />
         </div>
       </a>
 
-      <div className="p-4 flex-1 flex flex-col">
+      <div className="p-4">
         <a href={href} className="link-plain">
           <h2 className="text-base md:text-lg font-semibold leading-snug line-clamp-2">
             {post.title}


### PR DESCRIPTION
## Summary
- ensure blog list uses consistent multi-column grid via inline style
- unify post card image aspect ratio with 16:9 fill container

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ac7b894344832381ba667da5bc69c6