### PR TITLE
fix: improve blog card layout and images

### DIFF
--- a/app/blog/page/[page]/page.tsx
+++ b/app/blog/page/[page]/page.tsx
@@ -27,7 +27,11 @@ export default async function BlogPagedPage({ params }: { params: { page: string
       <div className="mx-auto max-w-6xl px-4 py-10">
         <h1 className="text-2xl font-bold text-[color:var(--ink)] heading-underline">記事一覧（{pageNum} / {totalPages}）</h1>
 
-        <div className="mt-8 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+        {/* auto-fill + minmax で常に複数カラム化 */}
+        <div
+          className="mt-8 grid gap-8"
+          style={{ gridTemplateColumns: "repeat(auto-fill, minmax(320px, 1fr))" }}
+        >
           {items.map(p => (
             <PostCard key={p.slug} post={p} />
           ))}

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -7,8 +7,8 @@ export default function PostCard({ post }: { post: any }) {
   return (
     <article className="card overflow-hidden">
       <a href={href} className="block">
-        {/* 16:9 の器 + 最大200pxでクランプ */}
-        <div className="relative aspect-[16/9] w-full max-h-[200px]">
+        {/* 高さ200pxの器 + fill */}
+        <div className="relative w-full h-[200px]">
           <Image
             src={src}
             alt={post.title}


### PR DESCRIPTION
## Summary
- ensure paginated blog listing uses auto-fill grid to avoid single-column fallback
- enforce fixed 200px thumbnail wrapper with `Image.fill` for uniform card images

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ad9c7c86848323a2987696e8fc9cb2