### PR TITLE
Fix blog grid layout and card images

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -12,10 +12,7 @@ export default async function BlogIndex() {
         <h1 className="text-2xl font-bold heading-underline">記事一覧</h1>
 
         {/* auto-fill + minmax で常に複数カラム化 */}
-        <div
-          className="mt-8 grid gap-8"
-          style={{ gridTemplateColumns: "repeat(auto-fill, minmax(320px, 1fr))" }}
-        >
+        <div className="mt-8 posts-grid">
           {posts.map((p) => (
             <PostCard key={p.slug} post={p} />
           ))}

--- a/app/blog/page/[page]/page.tsx
+++ b/app/blog/page/[page]/page.tsx
@@ -28,10 +28,7 @@ export default async function BlogPagedPage({ params }: { params: { page: string
         <h1 className="text-2xl font-bold text-[color:var(--ink)] heading-underline">記事一覧（{pageNum} / {totalPages}）</h1>
 
         {/* auto-fill + minmax で常に複数カラム化 */}
-        <div
-          className="mt-8 grid gap-8"
-          style={{ gridTemplateColumns: "repeat(auto-fill, minmax(320px, 1fr))" }}
-        >
+        <div className="mt-8 posts-grid">
           {items.map(p => (
             <PostCard key={p.slug} post={p} />
           ))}

--- a/app/globals.css
+++ b/app/globals.css
@@ -447,7 +447,7 @@ h1.page-title{ font-size:clamp(28px,5vw,40px); line-height:1.2; margin:24px 0 8p
 
 /* ========== Cards */
 .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 28px; margin-top: 22px; }
-.card { display: grid; grid-template-rows: 180px auto; border-radius: 16px; background: #fff;
+.card { border-radius: 16px; background: #fff;
   box-shadow: 0 12px 28px rgba(0,0,0,.06); text-decoration: none; color: inherit; overflow: hidden;
   transition: transform .18s ease, box-shadow .18s ease; }
 .card:hover { transform: translateY(-4px); box-shadow: 0 18px 38px rgba(0,0,0,.1); }
@@ -632,3 +632,13 @@ a:hover {
 /* 表の横スクロール（スマホ可読性UP） */
 .prose table{ display:block;width:100%;overflow-x:auto; }
 .prose thead,.prose tbody,.prose tr{ width:max-content; }
+
+/* 一覧カードのグリッドを強制（取りこぼし対策） */
+.posts-grid{
+  display:grid !important;
+  grid-template-columns:repeat(auto-fill,minmax(320px,1fr)) !important;
+  gap:2rem !important;
+}
+
+/* .card に grid を当てていたら解除（幅バグの原因） */
+.card{ display:block; }

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -15,7 +15,6 @@ export default function PostCard({ post }: { post: any }) {
             fill
             className="object-cover"
             sizes="(min-width:1024px) 33vw, (min-width:640px) 50vw, 100vw"
-            priority={false}
           />
         </div>
       </a>


### PR DESCRIPTION
## Summary
- enforce `.posts-grid` for blog list layouts and reset card display
- simplify PostCard image to use 200px fixed-height container with fill

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68adac5999ac8323b7464ff617c39f1c