### PR TITLE
Ensure post card thumbnails stay fixed height

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -642,3 +642,17 @@ a:hover {
 
 /* .card に grid を当てていたら解除（幅バグの原因） */
 .card{ display:block; }
+
+/* 一覧カードのサムネ（高さ固定） */
+.post-card-thumb{
+  position: relative;
+  width: 100%;
+  height: 200px;              /* ←ここで固定 */
+  background: #f6f7fb;
+}
+.post-card-thumb [data-nimg="fill"]{ object-fit: cover; }
+
+/* 取りこぼしがあっても絶対に200pxにするロック */
+.card > a:first-child { display:block !important; }
+.card > a:first-child .post-card-thumb { height:200px !important; }
+.card > a:first-child [data-nimg="fill"] { object-fit:cover !important; }

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -2,13 +2,13 @@ import Image from "next/image";
 
 export default function PostCard({ post }: { post: any }) {
   const href = `/blog/posts/${post.slug}`;
-  const src = post.thumb ?? "/images/no-thumb.png";
+  const src  = post.thumb ?? "/images/no-thumb.png";
 
   return (
     <article className="card overflow-hidden">
       <a href={href} className="block">
-        {/* 高さ200pxの器 + fill */}
-        <div className="relative w-full h-[200px]">
+        {/* 高さ200pxの器に fill で収める → サムネは常に同じ高さ */}
+        <div className="post-card-thumb">
           <Image
             src={src}
             alt={post.title}
@@ -27,7 +27,7 @@ export default function PostCard({ post }: { post: any }) {
         </a>
         <p className="mt-2 text-sm text-gray-500 line-clamp-2">{post.description}</p>
 
-        {post.tags?.length > 0 && (
+        {Array.isArray(post.tags) && post.tags.length > 0 && (
           <div className="mt-3 flex flex-wrap gap-2">
             {post.tags.slice(0, 3).map((t: string) => (
               <a key={t} href={`/blog/tags/${encodeURIComponent(t)}`} className="tag-chip">


### PR DESCRIPTION
## Summary
- fix PostCard component to wrap thumbnails in a fixed-height container
- add CSS to lock card thumbnails at 200px with object-fit cover

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found; attempted `npm install` but got 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68adc7f24590832390a57953453833c8