### PR TITLE
Tighten blog card grid and center article layout

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -11,11 +11,8 @@ export default async function BlogIndex() {
       <div className="mx-auto max-w-6xl px-4 py-10">
         <h1 className="text-2xl font-bold heading-underline">記事一覧</h1>
 
-        {/* auto-fill + minmax で常に複数カラム化 */}
         <div className="mt-8 posts-grid">
-          {posts.map((p) => (
-            <PostCard key={p.slug} post={p} />
-          ))}
+          {posts.map(p => <PostCard key={p.slug} post={p} />)}
         </div>
       </div>
     </main>

--- a/app/blog/page/[page]/page.tsx
+++ b/app/blog/page/[page]/page.tsx
@@ -27,11 +27,8 @@ export default async function BlogPagedPage({ params }: { params: { page: string
       <div className="mx-auto max-w-6xl px-4 py-10">
         <h1 className="text-2xl font-bold text-[color:var(--ink)] heading-underline">記事一覧（{pageNum} / {totalPages}）</h1>
 
-        {/* auto-fill + minmax で常に複数カラム化 */}
         <div className="mt-8 posts-grid">
-          {items.map(p => (
-            <PostCard key={p.slug} post={p} />
-          ))}
+          {items.map(p => <PostCard key={p.slug} post={p} />)}
         </div>
 
         <nav className="mt-10 flex items-center justify-between">

--- a/app/globals.css
+++ b/app/globals.css
@@ -633,26 +633,23 @@ a:hover {
 .prose table{ display:block;width:100%;overflow-x:auto; }
 .prose thead,.prose tbody,.prose tr{ width:max-content; }
 
-/* 一覧カードのグリッドを強制（取りこぼし対策） */
+/* 一覧のグリッドを強制（取りこぼし対策） */
 .posts-grid{
-  display:grid !important;
-  grid-template-columns:repeat(auto-fill,minmax(320px,1fr)) !important;
-  gap:2rem !important;
+  display: grid !important;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)) !important;
+  gap: 1.25rem !important; /* 20px */
 }
 
-/* .card に grid を当てていたら解除（幅バグの原因） */
-.card{ display:block; }
+/* カードの初期 display:grid を無効化（幅バグの元凶） */
+.card{ display: block !important; }
 
-/* 一覧カードのサムネ（高さ固定） */
+/* サムネ：さらに低めに固定（→視覚的に1/4程度に） */
 .post-card-thumb{
   position: relative;
   width: 100%;
-  height: 200px;              /* ←ここで固定 */
+  height: 150px;            /* ↓ 前回200px → 150px に */
   background: #f6f7fb;
 }
+@media (min-width: 640px){ .post-card-thumb{ height: 160px; } }  /* sm: */
+@media (min-width:1024px){ .post-card-thumb{ height: 170px; } }  /* lg: */
 .post-card-thumb [data-nimg="fill"]{ object-fit: cover; }
-
-/* 取りこぼしがあっても絶対に200pxにするロック */
-.card > a:first-child { display:block !important; }
-.card > a:first-child .post-card-thumb { height:200px !important; }
-.card > a:first-child [data-nimg="fill"] { object-fit:cover !important; }

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -94,7 +94,7 @@ export default async function PostPage({ params }: { params: { slug: string } })
   return (
     <>
       <main className="bg-page">
-        <div className="mx-auto max-w-3xl px-4 py-10">
+        <div className="mx-auto max-w-5xl px-4 py-10">    {/* 余白を左右に少し広げる */}
           {hasTOC && (
             <details className="md:hidden toc-mobile mb-6">
               <summary>目次</summary>
@@ -110,66 +110,68 @@ export default async function PostPage({ params }: { params: { slug: string } })
               </aside>
             )}
 
-            <article className="md:col-span-8 card prose prose-neutral md:prose-lg p-6">
-              <header className="mb-6">
-                <h1 className="text-2xl font-bold">{post.title}</h1>
-                <time className="mt-2 block text-sm text-[color:var(--muted)]">
-                  {new Date(post.date).toLocaleDateString("ja-JP")}
-                </time>
+            <article className="md:col-span-8 card p-6">
+              <div className="prose prose-neutral md:prose-lg mx-auto">
+                <header className="mb-6">
+                  <h1 className="text-2xl font-bold">{post.title}</h1>
+                  <time className="mt-2 block text-sm text-[color:var(--muted)]">
+                    {new Date(post.date).toLocaleDateString("ja-JP")}
+                  </time>
 
-                {hero && (
-                  <div className="relative mx-auto mt-4 w-full max-w-3xl overflow-hidden rounded-xl border bg-gray-100 aspect-[16/9] max-h-[320px] md:max-h-[380px]">
-                    <Image
-                      src={hero}
-                      alt={post.title}
-                      fill
-                      priority={false}
-                      sizes="(max-width:640px) 100vw, 768px"
-                      className="object-cover img-reset"
-                    />
-                  </div>
-                )}
-              </header>
-
-              {post.tags?.length > 0 && (
-                <ul className="mt-3 flex flex-wrap gap-2">
-                  {post.tags.map((t: string) => (
-                    <li key={t}>
-                      <TagChip tag={t} />
-                    </li>
-                  ))}
-                </ul>
-              )}
-
-              <div className="mt-6" dangerouslySetInnerHTML={{ __html: post.html }} />
-
-              <nav className="mt-10 flex justify-between text-sm">
-                <div>
-                  {prev && (
-                    <a href={`/blog/posts/${prev.slug}`} className="link-plain">
-                      ← {prev.title}
-                    </a>
+                  {hero && (
+                    <div className="relative mx-auto mt-4 w-full max-w-3xl overflow-hidden rounded-xl border bg-gray-100 aspect-[16/9] max-h-[320px] md:max-h-[380px]">
+                      <Image
+                        src={hero}
+                        alt={post.title}
+                        fill
+                        priority={false}
+                        sizes="(max-width:640px) 100vw, 768px"
+                        className="object-cover img-reset"
+                      />
+                    </div>
                   )}
-                </div>
-                <div>
-                  {next && (
-                    <a href={`/blog/posts/${next.slug}`} className="link-plain">
-                      {next.title} →
-                    </a>
-                  )}
-                </div>
-              </nav>
+                </header>
 
-              {related?.length > 0 && (
-                <section aria-labelledby="related" className="mt-12">
-                  <h2 id="related" className="text-lg font-semibold">関連記事</h2>
-                  <div className="mt-4 grid grid-cols-1 gap-6 sm:grid-cols-2">
-                    {related.map((p: any) => (
-                      <PostCard key={p.slug} post={p} />
+                {post.tags?.length > 0 && (
+                  <ul className="mt-3 flex flex-wrap gap-2">
+                    {post.tags.map((t: string) => (
+                      <li key={t}>
+                        <TagChip tag={t} />
+                      </li>
                     ))}
+                  </ul>
+                )}
+
+                <div className="mt-6" dangerouslySetInnerHTML={{ __html: post.html }} />
+
+                <nav className="mt-10 flex justify-between text-sm">
+                  <div>
+                    {prev && (
+                      <a href={`/blog/posts/${prev.slug}`} className="link-plain">
+                        ← {prev.title}
+                      </a>
+                    )}
                   </div>
-                </section>
-              )}
+                  <div>
+                    {next && (
+                      <a href={`/blog/posts/${next.slug}`} className="link-plain">
+                        {next.title} →
+                      </a>
+                    )}
+                  </div>
+                </nav>
+
+                {related?.length > 0 && (
+                  <section aria-labelledby="related" className="mt-12">
+                    <h2 id="related" className="text-lg font-semibold">関連記事</h2>
+                    <div className="mt-4 grid grid-cols-1 gap-6 sm:grid-cols-2">
+                      {related.map((p: any) => (
+                        <PostCard key={p.slug} post={p} />
+                      ))}
+                    </div>
+                  </section>
+                )}
+              </div>
             </article>
           </div>
         </div>

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -5,10 +5,9 @@ export default function PostCard({ post }: { post: any }) {
   const src  = post.thumb ?? "/images/no-thumb.png";
 
   return (
-    <article className="card overflow-hidden">
+    <article className="card overflow-hidden block">  {/* display:block を明示 */}
       <a href={href} className="block">
-        {/* 高さ200pxの器に fill で収める → サムネは常に同じ高さ */}
-        <div className="post-card-thumb">
+        <div className="post-card-thumb">              {/* ← 上のCSSが効く */}
           <Image
             src={src}
             alt={post.title}


### PR DESCRIPTION
## Summary
- Force grid layout for post listings and shrink thumbnail heights to 150–170px
- Ensure PostCard renders as block-level elements for consistent widths
- Widen and center article pages with an inner prose container

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm install` *(fails: 403 Forbidden accessing npm registry)*

------
https://chatgpt.com/codex/tasks/task_b_68add0b68ef88323bee4f6451148f2db