### PR TITLE
Refine blog card layout and center article view

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -633,23 +633,23 @@ a:hover {
 .prose table{ display:block;width:100%;overflow-x:auto; }
 .prose thead,.prose tbody,.prose tr{ width:max-content; }
 
-/* 一覧のグリッドを強制（取りこぼし対策） */
+/* 一覧のグリッドを確実に（取りこぼし対策） */
 .posts-grid{
   display: grid !important;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)) !important;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)) !important;
   gap: 1.25rem !important; /* 20px */
 }
 
-/* カードの初期 display:grid を無効化（幅バグの元凶） */
-.card{ display: block !important; }
-
-/* サムネ：さらに低めに固定（→視覚的に1/4程度に） */
+/* カードのサムネは 16:9。カード幅に応じて自動で高さが決まる（約180px） */
 .post-card-thumb{
   position: relative;
   width: 100%;
-  height: 150px;            /* ↓ 前回200px → 150px に */
+  aspect-ratio: 16/9;              /* ← 高さを比率で固定 */
+  overflow: hidden;
+  border-radius: 12px;
   background: #f6f7fb;
 }
-@media (min-width: 640px){ .post-card-thumb{ height: 160px; } }  /* sm: */
-@media (min-width:1024px){ .post-card-thumb{ height: 170px; } }  /* lg: */
 .post-card-thumb [data-nimg="fill"]{ object-fit: cover; }
+
+/* 念のため：.card に grid 指定が残っていたら無効化 */
+.card{ display: block !important; }

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -94,24 +94,17 @@ export default async function PostPage({ params }: { params: { slug: string } })
   return (
     <>
       <main className="bg-page">
-        <div className="mx-auto max-w-5xl px-4 py-10">    {/* 余白を左右に少し広げる */}
+        <div className="mx-auto max-w-6xl px-4 py-10">
           {hasTOC && (
             <details className="md:hidden toc-mobile mb-6">
               <summary>目次</summary>
               <TableOfContents headings={post.headings} />
             </details>
           )}
-          <div className={`grid grid-cols-1 gap-8 md:grid-cols-12`}>
-            {hasTOC && (
-              <aside className="hidden md:block md:col-span-4 order-first">
-                <div className="toc-box">
-                  <TableOfContents headings={post.headings} />
-                </div>
-              </aside>
-            )}
 
-            <article className="md:col-span-8 card p-6">
-              <div className="prose prose-neutral md:prose-lg mx-auto">
+          <article className="card p-6">
+            {/* 本文カラムだけ中央寄せ＆読み幅制御 */}
+            <div className="prose prose-neutral md:prose-lg mx-auto">
                 <header className="mb-6">
                   <h1 className="text-2xl font-bold">{post.title}</h1>
                   <time className="mt-2 block text-sm text-[color:var(--muted)]">
@@ -173,7 +166,6 @@ export default async function PostPage({ params }: { params: { slug: string } })
                 )}
               </div>
             </article>
-          </div>
         </div>
       </main>
       <script

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -2,18 +2,19 @@ import Image from "next/image";
 
 export default function PostCard({ post }: { post: any }) {
   const href = `/blog/posts/${post.slug}`;
-  const src  = post.thumb ?? "/images/no-thumb.png";
+  const src = post.thumb ?? "/images/no-thumb.png";
 
   return (
-    <article className="card overflow-hidden block">  {/* display:block を明示 */}
-      <a href={href} className="block">
-        <div className="post-card-thumb">              {/* ← 上のCSSが効く */}
+    <article className="card overflow-hidden">
+      <a href={href} className="block group">
+        {/* 16:9の器 + fill */}
+        <div className="post-card-thumb">
           <Image
             src={src}
             alt={post.title}
             fill
-            className="object-cover"
             sizes="(min-width:1024px) 33vw, (min-width:640px) 50vw, 100vw"
+            className="object-cover transition-transform duration-300 group-hover:scale-[1.03]"
           />
         </div>
       </a>
@@ -25,11 +26,14 @@ export default function PostCard({ post }: { post: any }) {
           </h2>
         </a>
         <p className="mt-2 text-sm text-gray-500 line-clamp-2">{post.description}</p>
-
         {Array.isArray(post.tags) && post.tags.length > 0 && (
           <div className="mt-3 flex flex-wrap gap-2">
             {post.tags.slice(0, 3).map((t: string) => (
-              <a key={t} href={`/blog/tags/${encodeURIComponent(t)}`} className="tag-chip">
+              <a
+                key={t}
+                href={`/blog/tags/${encodeURIComponent(t)}`}
+                className="tag-chip"
+              >
                 {t}
               </a>
             ))}


### PR DESCRIPTION
## Summary
- Ensure post listing grid uses 16:9 card thumbnails
- Center article content in a wider container
- Add hover scaling and grouping for post cards

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68aed8e7aa4c83239611ef39a8910d3b