### PR TITLE
Refine blog card grid and center article layout

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -11,8 +11,13 @@ export default async function BlogIndex() {
       <div className="mx-auto max-w-6xl px-4 py-10">
         <h1 className="text-2xl font-bold heading-underline">記事一覧</h1>
 
-        <div className="mt-8 posts-grid">
-          {posts.map(p => <PostCard key={p.slug} post={p} />)}
+        <div
+          className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3"
+          id="posts-grid"
+        >
+          {posts.map((p) => (
+            <PostCard key={p.slug} post={p} />
+          ))}
         </div>
       </div>
     </main>

--- a/app/globals.css
+++ b/app/globals.css
@@ -653,3 +653,6 @@ a:hover {
 
 /* 念のため：.card に grid が残っていたら打ち消す */
 .card{ display: block !important; }
+
+/* 一覧カードのグリッド（保険で） */
+#posts-grid { gap: 1.5rem; }

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -102,59 +102,56 @@ export default async function PostPage({ params }: { params: { slug: string } })
             </details>
           )}
 
-          <article className="card p-6">
-            {/* 本文カラムだけ中央寄せ＆読み幅制御 */}
-            <div className="prose prose-neutral md:prose-lg mx-auto">
-                <header className="mb-6">
-                  <h1 className="text-2xl font-bold">{post.title}</h1>
-                  <time className="mt-2 block text-sm text-[color:var(--muted)]">
-                    {new Date(post.date).toLocaleDateString("ja-JP")}
-                  </time>
+          <article className="prose prose-neutral md:prose-lg mx-auto max-w-3xl">
+            <header className="mb-6">
+              <h1 className="text-2xl font-bold">{post.title}</h1>
+              <time className="mt-2 block text-sm text-[color:var(--muted)]">
+                {new Date(post.date).toLocaleDateString("ja-JP")}
+              </time>
 
-                  {hero && (
-                    <div className="relative mx-auto mt-4 w-full max-w-3xl overflow-hidden rounded-xl border bg-gray-100 aspect-[16/9] max-h-[320px] md:max-h-[380px]">
-                      <Image
-                        src={hero}
-                        alt={post.title}
-                        fill
-                        priority={false}
-                        sizes="(max-width:640px) 100vw, 768px"
-                        className="object-cover img-reset"
-                      />
-                    </div>
-                  )}
-                </header>
+              {hero && (
+                <div className="relative mx-auto mt-4 w-full max-w-3xl overflow-hidden rounded-xl border bg-gray-100 aspect-[16/9] max-h-[320px] md:max-h-[380px]">
+                  <Image
+                    src={hero}
+                    alt={post.title}
+                    fill
+                    priority={false}
+                    sizes="(max-width:640px) 100vw, 768px"
+                    className="object-cover img-reset"
+                  />
+                </div>
+              )}
+            </header>
 
-                {post.tags?.length > 0 && (
-                  <ul className="mt-3 flex flex-wrap gap-2">
-                    {post.tags.map((t: string) => (
-                      <li key={t}>
-                        <TagChip tag={t} />
-                      </li>
-                    ))}
-                  </ul>
+            {post.tags?.length > 0 && (
+              <ul className="mt-3 flex flex-wrap gap-2">
+                {post.tags.map((t: string) => (
+                  <li key={t}>
+                    <TagChip tag={t} />
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            <div className="mt-6" dangerouslySetInnerHTML={{ __html: post.html }} />
+
+            <nav className="mt-10 flex justify-between text-sm">
+              <div>
+                {prev && (
+                  <a href={`/blog/posts/${prev.slug}`} className="link-plain">
+                    ← {prev.title}
+                  </a>
                 )}
-
-                <div className="mt-6" dangerouslySetInnerHTML={{ __html: post.html }} />
-
-                <nav className="mt-10 flex justify-between text-sm">
-                  <div>
-                    {prev && (
-                      <a href={`/blog/posts/${prev.slug}`} className="link-plain">
-                        ← {prev.title}
-                      </a>
-                    )}
-                  </div>
-                  <div>
-                    {next && (
-                      <a href={`/blog/posts/${next.slug}`} className="link-plain">
-                        {next.title} →
-                      </a>
-                    )}
-                  </div>
-                </nav>
               </div>
-            </article>
+              <div>
+                {next && (
+                  <a href={`/blog/posts/${next.slug}`} className="link-plain">
+                    {next.title} →
+                  </a>
+                )}
+              </div>
+            </nav>
+          </article>
 
             {related?.length > 0 && (
               <section aria-labelledby="related" className="mt-12">

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -7,38 +7,38 @@ export default function PostCard({ post }: { post: any }) {
   return (
     <article className="card overflow-hidden">
       <a href={href} className="block group">
-        <div className="post-card-thumb">
+        <div className="post-card-thumb relative w-full aspect-[16/9]">
           <Image
             src={src}
             alt={post.title}
             fill
-            sizes="(min-width:1024px) 25vw, (min-width:640px) 33vw, 100vw" /* ←より小さめ提示 */
-            className="object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+            className="object-cover rounded-xl transition-transform duration-300 group-hover:scale-[1.03]"
+            sizes="(min-width:1024px) 33vw, (min-width:640px) 50vw, 100vw"
+            priority={false}
           />
         </div>
-      </a>
 
-      <div className="p-4">
-        <a href={href} className="link-plain">
+        <div className="p-4">
           <h2 className="text-base md:text-lg font-semibold leading-snug line-clamp-2">
             {post.title}
           </h2>
-        </a>
-        <p className="mt-2 text-sm text-gray-500 line-clamp-2">{post.description}</p>
-        {Array.isArray(post.tags) && post.tags.length > 0 && (
-          <div className="mt-3 flex flex-wrap gap-2">
-            {post.tags.slice(0, 3).map((t: string) => (
-              <a
-                key={t}
-                href={`/blog/tags/${encodeURIComponent(t)}`}
-                className="tag-chip"
-              >
-                {t}
-              </a>
-            ))}
-          </div>
-        )}
-      </div>
+          <p className="mt-2 text-sm text-gray-500 line-clamp-2">{post.description}</p>
+        </div>
+      </a>
+
+      {Array.isArray(post.tags) && post.tags.length > 0 && (
+        <div className="px-4 pb-4 flex flex-wrap gap-2">
+          {post.tags.slice(0, 3).map((t: string) => (
+            <a
+              key={t}
+              href={`/blog/tags/${encodeURIComponent(t)}`}
+              className="tag-chip"
+            >
+              {t}
+            </a>
+          ))}
+        </div>
+      )}
     </article>
   );
 }


### PR DESCRIPTION
## Summary
- display blog index in responsive grid with 16:9 thumbnail cards
- center and limit width of article content for easier reading
- add fallback CSS for post card grid and thumbnails

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68aefdc6b144832392f75db75018afe9