### PR TITLE
fix blog layout and card styling

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -5,19 +5,13 @@ export const revalidate = 60;
 
 export default async function BlogIndex() {
   const posts = await getAllPostsMeta();
-
   return (
     <main className="bg-page">
       <div className="mx-auto max-w-6xl px-4 py-10">
-        <h1 className="text-2xl font-bold heading-underline">記事一覧</h1>
+        <h1 className="text-2xl font-bold">記事一覧</h1>
 
-        <div
-          className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3"
-          id="posts-grid"
-        >
-          {posts.map((p) => (
-            <PostCard key={p.slug} post={p} />
-          ))}
+        <div className="posts-grid mt-6">
+          {posts.map((p:any) => <PostCard key={p.slug} post={p} />)}
         </div>
       </div>
     </main>

--- a/app/blog/page/[page]/page.tsx
+++ b/app/blog/page/[page]/page.tsx
@@ -25,9 +25,9 @@ export default async function BlogPagedPage({ params }: { params: { page: string
   return (
     <main className="bg-page">
       <div className="mx-auto max-w-6xl px-4 py-10">
-        <h1 className="text-2xl font-bold text-[color:var(--ink)] heading-underline">記事一覧（{pageNum} / {totalPages}）</h1>
+        <h1 className="text-2xl font-bold text-[color:var(--ink)]">記事一覧（{pageNum} / {totalPages}）</h1>
 
-        <div className="mt-8 posts-grid">
+        <div className="posts-grid mt-6">
           {items.map(p => <PostCard key={p.slug} post={p} />)}
         </div>
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -656,3 +656,47 @@ a:hover {
 
 /* 一覧カードのグリッド（保険で） */
 #posts-grid { gap: 1.5rem; }
+/* ========= 強制ホットフィックス ========= */
+
+/* 一覧カードのグリッドを確実にON（過去の display:block を完全に上書き） */
+.posts-grid{
+  display:grid !important;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)) !important;
+  gap: 16px !important;
+}
+
+/* サムネ：常に 16:9 の小ぶりカード。fill でも絶対にハミ出さない */
+.post-card-thumb{
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  border-radius: 12px;
+  background: var(--surface-weak, #f8fafc);
+}
+/* next/image(fill) が入るときの保険（必ずトリミング） */
+.post-card-thumb [data-nimg="fill"]{ object-fit: cover; }
+
+/* カード自体をブロック化（リンクで幅が壊れないように） */
+.card{ display:block !important; }
+
+/* 記事ページの本文ブロックを中央寄せ＆幅固定 */
+.post-page{
+  max-width: 760px;           /* ここで左右の広がりを決める */
+  margin-inline: auto;        /* 中央寄せ */
+  padding-inline: 16px;       /* スマホ余白 */
+}
+@media (min-width: 1024px){
+  .post-page{ max-width: 860px; }
+}
+
+/* 関連記事のグリッドも同じ見た目で並べる */
+.posts-grid--related{
+  display:grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 16px;
+}
+
+/* リンクの既定色を抑える（青リンクを落ち着かせる） */
+a{ color: inherit; text-decoration: none; }
+a:hover{ color: var(--brand, #2563eb); text-decoration: underline; text-underline-offset: 3px; }

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -94,7 +94,7 @@ export default async function PostPage({ params }: { params: { slug: string } })
   return (
     <>
       <main className="bg-page">
-        <div className="mx-auto max-w-6xl px-4 py-10">
+        <article className="post-page py-10">
           {hasTOC && (
             <details className="md:hidden toc-mobile mb-6">
               <summary>目次</summary>
@@ -102,68 +102,69 @@ export default async function PostPage({ params }: { params: { slug: string } })
             </details>
           )}
 
-          <article className="prose prose-neutral md:prose-lg mx-auto max-w-3xl">
-            <header className="mb-6">
-              <h1 className="text-2xl font-bold">{post.title}</h1>
-              <time className="mt-2 block text-sm text-[color:var(--muted)]">
-                {new Date(post.date).toLocaleDateString("ja-JP")}
-              </time>
+          <header className="mb-6">
+            <h1 className="text-2xl font-bold">{post.title}</h1>
+            <time className="mt-2 block text-sm text-[color:var(--muted)]">
+              {new Date(post.date).toLocaleDateString("ja-JP")}
+            </time>
 
-              {hero && (
-                <div className="relative mx-auto mt-4 w-full max-w-3xl overflow-hidden rounded-xl border bg-gray-100 aspect-[16/9] max-h-[320px] md:max-h-[380px]">
-                  <Image
-                    src={hero}
-                    alt={post.title}
-                    fill
-                    priority={false}
-                    sizes="(max-width:640px) 100vw, 768px"
-                    className="object-cover img-reset"
-                  />
-                </div>
+            {hero && (
+              <div className="relative mx-auto mt-4 w-full overflow-hidden rounded-xl border bg-gray-100 aspect-[16/9] max-h-[320px] md:max-h-[380px]">
+                <Image
+                  src={hero}
+                  alt={post.title}
+                  fill
+                  priority={false}
+                  sizes="(max-width:640px) 100vw, 768px"
+                  className="object-cover img-reset"
+                />
+              </div>
+            )}
+          </header>
+
+          {post.tags?.length > 0 && (
+            <ul className="mt-3 flex flex-wrap gap-2">
+              {post.tags.map((t: string) => (
+                <li key={t}>
+                  <TagChip tag={t} />
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <div
+            className="prose prose-neutral max-w-none mt-6"
+            dangerouslySetInnerHTML={{ __html: post.html }}
+          />
+
+          <nav className="mt-10 flex justify-between text-sm">
+            <div>
+              {prev && (
+                <a href={`/blog/posts/${prev.slug}`} className="link-plain">
+                  ← {prev.title}
+                </a>
               )}
-            </header>
+            </div>
+            <div>
+              {next && (
+                <a href={`/blog/posts/${next.slug}`} className="link-plain">
+                  {next.title} →
+                </a>
+              )}
+            </div>
+          </nav>
 
-            {post.tags?.length > 0 && (
-              <ul className="mt-3 flex flex-wrap gap-2">
-                {post.tags.map((t: string) => (
-                  <li key={t}>
-                    <TagChip tag={t} />
-                  </li>
+          {related?.length > 0 && (
+            <section className="mt-12">
+              <h2 className="text-base font-semibold mb-4">関連記事</h2>
+              <div className="posts-grid--related">
+                {related.map((p: any) => (
+                  <PostCard key={p.slug} post={p} />
                 ))}
-              </ul>
-            )}
-
-            <div className="mt-6" dangerouslySetInnerHTML={{ __html: post.html }} />
-
-            <nav className="mt-10 flex justify-between text-sm">
-              <div>
-                {prev && (
-                  <a href={`/blog/posts/${prev.slug}`} className="link-plain">
-                    ← {prev.title}
-                  </a>
-                )}
               </div>
-              <div>
-                {next && (
-                  <a href={`/blog/posts/${next.slug}`} className="link-plain">
-                    {next.title} →
-                  </a>
-                )}
-              </div>
-            </nav>
-          </article>
-
-            {related?.length > 0 && (
-              <section aria-labelledby="related" className="mt-12">
-                <h2 id="related" className="text-base font-semibold mb-4">関連記事</h2>
-                <div className="posts-grid">
-                  {related.map((p: any) => (
-                    <PostCard key={p.slug} post={p} />
-                  ))}
-                </div>
-              </section>
-            )}
-        </div>
+            </section>
+          )}
+        </article>
       </main>
       <script
         type="application/ld+json"

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -2,43 +2,38 @@ import Image from "next/image";
 
 export default function PostCard({ post }: { post: any }) {
   const href = `/blog/posts/${post.slug}`;
-  const src = post.thumb ?? "/images/no-thumb.png";
+  const src  = post.thumb ?? "/images/no-thumb.png";
 
   return (
-    <article className="card overflow-hidden">
+    <article className="card overflow-hidden group">
       <a href={href} className="block group">
-        <div className="post-card-thumb relative w-full aspect-[16/9]">
+        <div className="post-card-thumb">
           <Image
             src={src}
             alt={post.title}
             fill
-            className="object-cover rounded-xl transition-transform duration-300 group-hover:scale-[1.03]"
-            sizes="(min-width:1024px) 33vw, (min-width:640px) 50vw, 100vw"
             priority={false}
+            sizes="(min-width:1024px) 320px, (min-width:640px) 50vw, 100vw"
+            className="transition-transform duration-300 group-hover:scale-[1.02]"
           />
-        </div>
-
-        <div className="p-4">
-          <h2 className="text-base md:text-lg font-semibold leading-snug line-clamp-2">
-            {post.title}
-          </h2>
-          <p className="mt-2 text-sm text-gray-500 line-clamp-2">{post.description}</p>
         </div>
       </a>
 
-      {Array.isArray(post.tags) && post.tags.length > 0 && (
-        <div className="px-4 pb-4 flex flex-wrap gap-2">
-          {post.tags.slice(0, 3).map((t: string) => (
-            <a
-              key={t}
-              href={`/blog/tags/${encodeURIComponent(t)}`}
-              className="tag-chip"
-            >
-              {t}
-            </a>
-          ))}
-        </div>
-      )}
+      <div className="p-4">
+        <h2 className="text-base md:text-lg font-semibold leading-snug line-clamp-2">
+          <a href={href} className="link-plain">{post.title}</a>
+        </h2>
+        {post.description && (
+          <p className="mt-1 text-sm text-gray-600 line-clamp-2">{post.description}</p>
+        )}
+        {Array.isArray(post.tags) && post.tags.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-2">
+            {post.tags.slice(0,3).map((t:string)=>(
+              <a key={t} href={`/blog/tags/${encodeURIComponent(t)}`} className="tag-chip">{t}</a>
+            ))}
+          </div>
+        )}
+      </div>
     </article>
   );
 }


### PR DESCRIPTION
## Summary
- enforce grid, post card, and layout hotfix styles
- replace PostCard component
- wrap listings in `.posts-grid` and center articles with `.post-page`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_b_68af0b8b47ec832384b5b886833e5d0a